### PR TITLE
quick fix for the seeder connection string

### DIFF
--- a/tools/dbHelper.js
+++ b/tools/dbHelper.js
@@ -1,12 +1,17 @@
 import mongoose from 'mongoose'
 import consola from 'consola'
 require('dotenv').config()
-
+const db = process.env.VUE_APP_CONNECTION_STRING
+  ? process.env.VUE_APP_CONNECTION_STRING.replace(
+    '-password-',
+    process.env.VUE_APP_RMP_DB_PASSWORD
+  )
+  : 'empty connection string check environment vars'
 // Initialise connection to database
 export const init = () => {
   return new Promise((resolve, reject) => {
     mongoose
-      .connect(process.env.VUE_APP_CONNECTION_STRING, {
+      .connect(db, {
         useNewUrlParser: true
       })
       .catch(err => consola.ready({ message: err }))


### PR DESCRIPTION
# Description

Minor bug in the seeder code stopping it from connecting to the staging database. Just needed the password interpolation piece from the main app :+1: 

## Test Instructions

1. Deploy the app to staging
1. execute `npm run seed`

## Checklist
- [ ] Unit tests have been added/updated
