### PR TITLE
Added fonts to global theme + Added contact form component to toggle

### DIFF
--- a/components/app/AppNavAdding.vue
+++ b/components/app/AppNavAdding.vue
@@ -1,11 +1,11 @@
 <template>
   <div id="navContainer">
     <div class="mt-24">
-      <h2 class="newAdd">
+      <h2 class="newAdd font-display">
         Add new
       </h2>
       <div>
-        <p class="orange requireFields t-2">
+        <p class="orange requireFields t-2 font-body">
           Required field
         </p>
       </div>
@@ -30,7 +30,9 @@
       </button>
     </div>
     <div class="mt-12">
-      <ConFormFields v-if="!isSelected" />
+      <ConFormFields v-if="!isSelected">
+        <contact-form />
+      </ConFormFields>
       <EngFormFields v-if="isSelected">
         <engagement-form />
       </EngFormFields>
@@ -40,9 +42,11 @@
 
 <script>
 import EngagementForm from '../engagement/EngForm.vue'
+import ContactForm from '../contact/ContactForm.vue'
 export default {
   components: {
-    EngagementForm
+    EngagementForm,
+    ContactForm
   },
   data() {
     return {
@@ -50,7 +54,7 @@ export default {
       bgColorCon: '',
       txtColorEng: 'white',
       bgColorEng: '#2572b4',
-      isSelected: false
+      isSelected: true
     }
   },
   methods: {
@@ -75,14 +79,11 @@ export default {
 
 <style>
 .newAdd {
-  font-family: 'Lato Bold', 'Lato Regular', 'Lato';
   font-weight: 600;
-  font-style: normal;
   font-size: 48px;
   color: #426177;
 }
 .requireFields {
-  font-family: 'Noto Sans Bold', 'Noto Sans Regular', 'Noto Sans';
   font-weight: 700;
   font-style: normal;
   color: #d87c4f;
@@ -98,7 +99,7 @@ button.left {
   display: inline-block;
   font-size: 16px;
   outline: 0;
-  @apply cursor-pointer font-serif;
+  @apply cursor-pointer font-display;
 }
 button.right {
   border-top-right-radius: 35px;
@@ -112,7 +113,7 @@ button.right {
   display: inline-block;
   font-size: 16px;
   outline: 0;
-  @apply cursor-pointer font-serif;
+  @apply cursor-pointer font-display;
 }
 .orange {
   background-image: url('../../assets/images/orange-star.png');

--- a/components/app/AppNavBtn.vue
+++ b/components/app/AppNavBtn.vue
@@ -77,7 +77,7 @@ button:focus {
 
 button.switch {
   padding: 25px;
-  @apply cursor-pointer text-3xl font-serif font-bold text-center w-full;
+  @apply cursor-pointer text-3xl font-display font-bold text-center w-full;
 }
 
 @media (max-width: 660px) {

--- a/components/app/AppNavSearching.vue
+++ b/components/app/AppNavSearching.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="px-4">
     <div class="mt-24">
-      <h2 class="newAdd">
+      <h2 class="searchHeader font-display">
         Search
       </h2>
       <div>
-        <p class="orange requireFields t-2">
+        <p class="orange requireFields t-2 font-body">
           Required fields
         </p>
       </div>
@@ -115,15 +115,13 @@ export default {
 </script>
 
 <style>
-.newAdd {
-  font-family: 'Lato Bold', 'Lato Regular', 'Lato';
+.searchHeader {
   font-weight: 600;
   font-style: normal;
   font-size: 48px;
   color: #426177;
 }
 .requireFields {
-  font-family: 'Noto Sans Bold', 'Noto Sans Regular', 'Noto Sans';
   font-weight: 700;
   font-style: normal;
   color: #d87c4f;
@@ -139,7 +137,7 @@ button.left {
   display: inline-block;
   font-size: 16px;
   outline: 0;
-  @apply cursor-pointer font-serif;
+  @apply cursor-pointer font-display;
 }
 button.right {
   border-top-right-radius: 35px;
@@ -153,7 +151,7 @@ button.right {
   display: inline-block;
   font-size: 16px;
   outline: 0;
-  @apply cursor-pointer font-serif;
+  @apply cursor-pointer font-display;
 }
 .orange {
   background-image: url('../../assets/images/orange-star.png');

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -1,13 +1,13 @@
 <template>
   <!-- eslint-disable space-before-function-paren -->
-  <div class="contactForm">
+  <div class="contactForm font-body">
     <div>
-      <h1 class="title">
+      <h1 class="title font-display">
         {{ $t('contact.create') }}
       </h1>
 
       <div>
-        <p class="orange fontNoto">
+        <p class="orange font-body">
           {{ $t('contact.type') }}
         </p>
       </div>
@@ -32,7 +32,7 @@
         </div>
       </div>
 
-      <h2 class="title">
+      <h2 class="title font-display">
         {{ $t('contact.information') }}
       </h2>
 
@@ -184,7 +184,7 @@
           </div>
         </div>
 
-        <h2 class="title">
+        <h2 class="title font-display">
           {{ $t('contact.organization') }} <br />
           {{ $t('contact.information') }}
         </h2>
@@ -620,7 +620,6 @@ export default {
 .contactForm {
   width: 1200px;
   margin: auto;
-  font-family: 'DejaVu Serif', 'Roboto slab', 'sans-serif', 'Helvetica Neue';
   @apply bg-white text-black;
 }
 .title {
@@ -634,10 +633,6 @@ export default {
 }
 .formInput:focus {
   @apply outline-none border-blue-500;
-}
-.fontNoto {
-  font-family: 'Noto Sans', 'DejaVu Serif', 'Roboto slab', 'sans-serif',
-    'Helvetica Neue';
 }
 .orange {
   background-image: url('../../assets/images/orange-star.png');

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -1,7 +1,10 @@
 <template>
-  <div title="engagementForm" class="ml-12 font-serif">
+  <div title="engagementForm" class="ml-12">
+    <h1 class="text-5xl formTitle">
+      {{ $t('engSelect.engagement') }}
+    </h1>
     <select-contact />
-    <h1 class="title">
+    <h1 class="title font-display">
       {{ $t('engagement.engagment') }}
     </h1>
     <form @submit.prevent="submitForm(engagementDetail)">
@@ -9,7 +12,7 @@
         <div class="flex flex-wrap mb-8">
           <div class="max-w-lg sm:w-1/3 mb-4 mr-20">
             <label
-              class="orange block tracking-wide text-black text-md font-bold mb-2"
+              class="orange block tracking-wide text-black text-md font-bold font-body mb-2"
               for="subject"
             >
               {{ $t('engagement.subject') }}
@@ -25,7 +28,7 @@
 
           <div class="max-w-lg sm:w-1/3 mb-4">
             <label
-              class="orange block tracking-wide text-black text-md font-bold mb-2"
+              class="orange block tracking-wide text-black text-md font-bold font-body mb-2"
               for="type"
             >
               {{ $t('engagement.type') }}
@@ -64,7 +67,7 @@
         <div class="flex flex-wrap mb-8">
           <div class="max-w-lg w-2/3 mb-4 mr-20">
             <label
-              class="orange block tracking-wide text-black text-md font-bold mb-2"
+              class="orange block tracking-wide text-black text-md font-bold font-body mb-2"
               for="date"
             >
               {{ $t('engagement.date') }}
@@ -87,7 +90,7 @@
 
           <div class="max-w-lg sm:w-1/3 mb-4">
             <label
-              class="orange block tracking-wide text-black text-md font-bold mb-2"
+              class="orange block tracking-wide text-black text-md font-bold font-body mb-2"
               for="numParticipants"
             >
               {{ $t('engagement.participants') }}
@@ -113,7 +116,7 @@
         <div class="flex flex-wrap">
           <div class="w-full sm:w-6/12 mb-8">
             <label
-              class="orange block tracking-wide text-black text-md font-bold -mb-4"
+              class="orange block tracking-wide text-black text-md font-bold font-body mb-4"
               for="description"
             >
               {{ $t('engagement.description') }}
@@ -130,7 +133,7 @@
         <div class="flex flex-wrap mb-8">
           <div class="max-w-lg sm:w-1/3 mb-4 mr-20">
             <label
-              class="block tracking-wide text-black text-md font-bold mb-2"
+              class="block tracking-wide text-black text-md font-bold font-body mb-2"
               for="policyProgram"
             >
               {{ $t('engagement.policy') }}
@@ -146,7 +149,7 @@
 
           <div class="max-w-lg sm:w-1/3 mb-4">
             <label
-              class="block tracking-wide text-black text-md font-bold mb-2"
+              class="block tracking-wide text-black text-md font-bold font-body mb-2"
               for="tags"
             >
               {{ $t('engagement.tags') }}
@@ -162,7 +165,7 @@
         <div class="flex flex-wrap">
           <div class="w-full sm:w-6/12 mb-8">
             <label
-              class="block tracking-wide text-black text-md font-bold -mb-4"
+              class="block tracking-wide text-black text-md font-bold font-body mb-4"
               for="comments"
             >
               {{ $t('engagement.comments') }}
@@ -191,12 +194,12 @@
 
       <div class="flex justify-start mb-12">
         <div class="w-3/12 margins">
-          <AppButton custom_style="btn-cancel" data_cypress="formButton">
+          <AppButton class="font-display" custom_style="btn-cancel" data_cypress="formButton">
             {{ $t('engagement.save') }}
           </AppButton>
         </div>
         <div class="w-3/12 margins">
-          <AppButton custom_style="btn-extra" data_cypress="formButton">
+          <AppButton class="font-display" custom_style="btn-extra" data_cypress="formButton">
             {{ $t('engagement.save') }}
           </AppButton>
         </div>
@@ -314,9 +317,12 @@ export default {
 <style scoped>
 .title {
   font-weight: 600;
-  /* font-size: 35px; */
   color: #426177;
   @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-4xl pt-4;
+}
+.formTitle {
+  color: #246880;
+  @apply font-bold;
 }
 .btn-extra {
   @apply w-11/12 h-12 justify-start;

--- a/components/engagement/EngSelectContacts.vue
+++ b/components/engagement/EngSelectContacts.vue
@@ -1,14 +1,11 @@
 <template>
   <div class="contact mb-8">
-    <h1 class="text-5xl">
-      {{ $t('engSelect.engagement') }}
-    </h1>
     <h2 class="text-4xl">
       Contact
     </h2>
     <form class="relative mt-6 max-w-md">
       <label
-        class="orange block tracking-wide text-black text-md font-bold mb-2"
+        class="orange block tracking-wide text-black text-md font-bold font-body mb-2"
         for="subject"
       >
         {{ $t('engSelect.name') }}
@@ -32,7 +29,7 @@
         </button>
       </div>
       <div class="flex flex-row mt-2">
-        <button class="mr-4" @click.prevent="moreContacts=true">
+        <button class="mr-4 font-body" @click.prevent="moreContacts=true">
           {{ $t ('engSelect.add') }}
         </button>
         <div class="pt-1">

--- a/components/layout/AppFooterLinks.vue
+++ b/components/layout/AppFooterLinks.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="leading-10 bg-white">
     <div class="container-links">
-      <nav class="py-8 xl:flex xl:mx-10">
+      <nav class="py-8 xl:flex xl:mx-10 font-body">
         <ul
           id="fLinks"
           class="md:grid md:grid-cols-2 xl:flex xl:justify-between xl:mx-auto"

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -26,8 +26,6 @@ export default {}
 }
 
 .title {
-  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   display: block;
   font-weight: 300;
   font-size: 100px;

--- a/pages/search/engagement.vue
+++ b/pages/search/engagement.vue
@@ -32,8 +32,6 @@ export default {
 }
 
 .title {
-  font-family: 'Quicksand', 'Source Sans Pro', -apple-system, BlinkMacSystemFont,
-    'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
   display: block;
   font-weight: 300;
   font-size: 100px;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,6 +2,10 @@
 module.exports = {
   purge: ['./**/*.html', './**/*.vue', './**/*.jsx'],
   theme: {
+    fontFamily: {
+      display: ['Lato', 'sans-serif'],
+      body: ['Noto', 'sans-serif']
+    },
     extend: {
       colors: {
         'rmp-dk-blue': '#134164',


### PR DESCRIPTION
# Description

Up until now there was no common source of truth for the fonts and styling within the application. With this PR, the fonts from the style guide have been added to the tailwind global theme config and can be called on an element's class attribute using "font-display" (for headers and display text) and "font-body" (for all content text). I have modified our two forms and related components to utilize this, but there are still fixes required in the application in other pages/components.

Also, the add new contact form has been added to the button toggle for the "Add" section of the app.

## Test Instructions

1. Inspect form pages to see 'Lato' and 'Noto' being used for the displayed text

and

1. Navigate to "Add Contacts & Engagements"
2. Clock "Contacts" on the button toggle
3. See contact form displayed