### PR TITLE
language-fix

### DIFF
--- a/components/app/AppFilterForm.vue
+++ b/components/app/AppFilterForm.vue
@@ -6,7 +6,7 @@
           v-model="search"
           type="text"
           class="search-input"
-          placeholder="Search..."
+          :placeholder="$t('app.search')+'...'"
           @keyup="filter"
         />
       </div>

--- a/components/app/AppNavAdding.vue
+++ b/components/app/AppNavAdding.vue
@@ -2,11 +2,11 @@
   <div id="navContainer">
     <div class="mt-24">
       <h2 class="newAdd font-display">
-        Add new
+        {{ $t('app.add') }}
       </h2>
       <div>
         <p class="orange requireFields t-2 font-body">
-          Required field
+          {{ $t('form.required') }}
         </p>
       </div>
     </div>

--- a/components/app/AppNavSearching.vue
+++ b/components/app/AppNavSearching.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="px-4">
-    <div class="mt-24">
+    <div>
       <h2 class="searchHeader font-display">
-        Search
+        {{ $t('app.search') }}
       </h2>
       <div>
         <p class="orange requireFields t-2 font-body">
-          Required fields
+          {{ $t('form.required') }}
         </p>
       </div>
     </div>

--- a/components/layout/AppFooterLinks.vue
+++ b/components/layout/AppFooterLinks.vue
@@ -7,32 +7,32 @@
           class="md:grid md:grid-cols-2 xl:flex xl:justify-between xl:mx-auto"
         >
           <li>
-            <a href="https://www.canada.ca/en/social.html">
+            <a href="https://www.canada.ca/en/social.html" target="_blank">
               {{ $t('footer.social') }}
             </a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/mobile.html">
+            <a href="https://www.canada.ca/en/mobile.html" target="_blank">
               {{ $t('footer.mobile') }}
             </a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/government/about.html">
+            <a href="https://www.canada.ca/en/government/about.html" target="_blank">
               {{ $t('footer.about') }}
             </a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/transparency/terms.html">
+            <a href="https://www.canada.ca/en/transparency/terms.html" target="_blank">
               {{ $t('footer.terms') }}
             </a>
           </li>
           <li>
-            <a href="https://www.canada.ca/en/transparency/privacy.html">
+            <a href="https://www.canada.ca/en/transparency/privacy.html" target="_blank">
               {{ $t('footer.privacy') }}
             </a>
           </li>
           <li>
-            <a href="https://home.dts-stn.com/">
+            <a href="https://home.dts-stn.com/" target="_blank">
               {{ $t('footer.dts') }}
             </a>
           </li>

--- a/components/layout/AppHeader.vue
+++ b/components/layout/AppHeader.vue
@@ -31,19 +31,20 @@
             :alt="$t('header.homeAlt')"
           />
         </nuxt-link>
-        <span class="hidden sm:block pt-5">
+        <span class="hidden sm:block pt-5 text-2xl">
           Text placeholder
         </span>
         <div id="userInfo">
           <div class="flex p-6">
             <ul class="underline mr-2">
               <li>
-                <nuxt-link :to="localePath('/dashboard')" data-cy="dashboard-link">
+                <nuxt-link :to="localePath('/dashboard')" data-cy="dashboard-link" class="text-xl">
                   {{ $t('header.dashboard') }}
                 </nuxt-link>
               </li>
               <li>
-                <a href="#">
+                <!-- This <a> tag will probably be a nuxt-link once we get the account system going. -->
+                <a href="#" class="text-xl">
                   {{ $t('header.logout') }}
                 </a>
               </li>
@@ -76,8 +77,8 @@ export default {
   @apply bg-local bg-top bg-cover bg-no-repeat bg-white;
 }
 #userImg {
-  height: 50px;
-  width: 50px;
+  height: 60px;
+  width: 60px;
   background-color: #bbb;
   border-radius: 50%;
   display: inline-block;

--- a/components/layout/AppNavBtn.vue
+++ b/components/layout/AppNavBtn.vue
@@ -8,7 +8,7 @@
         :style="{ color: txtColorAdd, 'background-color': bgColorAdd, 'box-shadow': boxShadowAdd }"
         @click.native="colorChange(true)"
       >
-        Search contacts & engagements
+        {{ $t('NavBtn.SearchConEn') }}
       </nuxt-link>
       <nuxt-link
         :to="localePath('/add/engagement')"
@@ -17,7 +17,7 @@
         :style="{ color: txtColorSearch, 'background-color': bgColorSearch, 'box-shadow': boxShadowSearch }"
         @click.native="colorChange(false)"
       >
-        Add contacts & engagements
+        {{ $t('NavBtn.AddConEn') }}
       </nuxt-link>
     </div>
   </div>

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -5,7 +5,7 @@ export default {
   welcome: 'relationship management portal proof of concept!',
   getstarted: 'Get Started',
   form: {
-    test: 'test'
+    required: 'Required Fields'
   },
 
   // header
@@ -35,7 +35,9 @@ export default {
   // app
   app: {
     dts: 'dts-rmp',
-    welcome: 'relationship management portal proof of concept!'
+    welcome: 'relationship management portal proof of concept!',
+    search: 'Search',
+    add: 'Add'
   },
 
   // error pages

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -5,7 +5,7 @@ export default {
   welcome: 'preuve de concept du portail de gestion des relations!',
   getstarted: 'Commencer',
   form: {
-    test: 'test'
+    required: 'Champs Obligatoires'
   },
 
   // header
@@ -35,7 +35,9 @@ export default {
   // app
   app: {
     dts: 'dts-rmp-French',
-    welcome: 'relationship management portal proof of concept!'
+    welcome: 'relationship management portal proof of concept!',
+    search: 'Recherche',
+    add: 'Ajouter'
   },
 
   // error pages

--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -1,4 +1,5 @@
 <template>
+  <!-- This page has no french trasnlation since we do not know the dropdowns official values. -->
   <div class="px-10 py-5 xl:px-64">
     <div class="sm:flex sm:w-full">
       <div class="mx-2 sm:w-3/4">
@@ -11,13 +12,12 @@
         <input
           id="pdfButton"
           type="button"
-          value="Download PDF"
+          :value="$t('footer.symbol')"
           class="md:float-right"
         />
       </div>
     </div>
     <div>
-      <!-- This form might be a component -->
       <form class="sm:flex">
         <AppSelect
           modelname="hello"

--- a/pages/search/contact.vue
+++ b/pages/search/contact.vue
@@ -1,6 +1,16 @@
 <template>
-  <AppNavSearching @filterResults="filter" />
+  <div class="main pt-1">
+    <div>
+      <h1 class="title">
+        {{ $t('app.dts') }}
+      </h1>
+      <h2 class="subtitle">
+        Contact
+      </h2>
+    </div>
+    <AppNavSearching @filterResults="filter" />
   <!-- Loop through contacts here. look at 'search/engagement' for guidance -->
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
# Description

Change hard coded strings to use language toggle.
Change some font sizing in the header.
Change every link to target _blank.
Organised the add and search pages to look a little bit more alike.

I did not add translation for the dashboard since we do not know what are the final drop-down options.

## Test Instructions

For the header:
Text placeholder, dashboard and log out are bigger.

As for the rest, navigate through the website and notice the French to English toggle.

## Help Requested


## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
