### PR TITLE
Adding "subject" field to Engagements model

### DIFF
--- a/api/models/engagement.js
+++ b/api/models/engagement.js
@@ -2,6 +2,7 @@ import { Schema, model } from 'mongoose'
 
 const EngagementSchema = new Schema({
   type: { type: String, required: true },
+  subject: { type: String, required: true },
   date: { type: Date, required: true },
   description: { type: String, required: true },
   numParticipants: { type: Number, required: true },

--- a/test/db/engagement.test.js
+++ b/test/db/engagement.test.js
@@ -6,6 +6,7 @@ const engagementData = {
   engagements: [],
   tags: ['Architercture', 'Planning', 'Business Delivery'],
   type: 'Scrum/Sprint',
+  subject: 'Analysis',
   date: Date('2020-06-19T15:04:35.000Z'),
   description:
     'PSMJCyefyOcVVkNmuFVqZkLZTKMzLOfgtuudqrpVODrAvrKgpFMFlCgKnWKqNSITxCLXQbCBTuTyZPfeEFGXDvHmKbccxsRTTWolybkkOXCBPfeERNIdWxguugCWLybnTFvqDNBZPmtBXZEOvrPMia',
@@ -17,6 +18,7 @@ const engagementDataInvalidField = {
   engagements: [],
   tags: ['Architercture', 'Planning', 'Business Delivery'],
   type: 'Scrum/Sprint',
+  subject: 'Analysis',
   date: Date('2020-06-19T15:04:35.000Z'),
   time: Date(),
   description:
@@ -29,6 +31,7 @@ const engagementDataMissingReqField = {
   engagements: [],
   tags: ['Architercture', 'Planning', 'Business Delivery'],
   type: 'Scrum/Sprint',
+  subject: 'Analysis',
   description:
     'PSMJCyefyOcVVkNmuFVqZkLZTKMzLOfgtuudqrpVODrAvrKgpFMFlCgKnWKqNSITxCLXQbCBTuTyZPfeEFGXDvHmKbccxsRTTWolybkkOXCBPfeERNIdWxguugCWLybnTFvqDNBZPmtBXZEOvrPMia',
   numParticipants: 5,

--- a/tools/seeder/seeder.js
+++ b/tools/seeder/seeder.js
@@ -61,6 +61,7 @@ const populateDatabase = async() => {
   for (let j = 0; j < numEngagements; j++) {
     await Engagements.create({
       type: Randomizers.randomEngagementType(),
+      subject: Randomizers.randomString(10),
       date: Date(),
       description: Randomizers.randomString(150),
       numParticipants: Randomizers.randomInt(2, 5),


### PR DESCRIPTION
# Description

`subject` field was missing from the Engagements model. It is now added.

## Test Instructions

1. View model and seeder code
1. See that subject is now a field of the Engagements model and is seeded
