### PR TITLE
Deep Contact/Engagement navigation

### DIFF
--- a/api/routes/contact.js
+++ b/api/routes/contact.js
@@ -34,7 +34,7 @@ router.get('/contacts', async(req, res) => {
 
 router.get('/contact', async(req, res) => {
   try {
-    const contact = await Contact.findById(req.query.id)
+    const contact = await Contact.findById(req.query.id).populate('engagements')
 
     if (!contact) {
       consola.error('No contact exist')

--- a/api/routes/engagement.js
+++ b/api/routes/engagement.js
@@ -31,7 +31,7 @@ router.get('/engagements', async(req, res) => {
 
 router.get('/engagement', async(req, res) => {
   try {
-    const engagement = await Engagement.findById(req.query.id)
+    const engagement = await Engagement.findById(req.query.id).populate('contacts')
 
     if (!engagement) {
       consola.error('No engagement exist')

--- a/pages/view/contact/_id.vue
+++ b/pages/view/contact/_id.vue
@@ -52,8 +52,18 @@
     </h2>
 
     <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
-      <ConShowEngagaments :index="0" :tags="['tag1', 'tag2', 'tag3']" />
-      <ConShowEngagaments :tags="['tagX1', 'tagX2', 'tagX3']" />
+      <ConShowEngagaments
+        v-for="(eng, index) in contactInfo.engagements"
+        :id="eng._id"
+        :key="index"
+        :index="index"
+        :type="eng.type"
+        :contacts="eng.contacts"
+        :tags="eng.tags"
+        :date="(eng.date).substring(0, 10)"
+        :description="eng.description"
+        :number="eng.numParticipants"
+      />
     </div>
 
     <div class="flex justify-start mb-4">
@@ -86,8 +96,17 @@ export default {
     AppButton
   },
 
+  async fetch() {
+    try {
+      await this.$store.dispatch('contacts/fetchContact', this.$route.params.id)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log('Error: ', e.response)
+    }
+  },
+
   computed: mapState({
-    contactInfo: state => state.contacts.contacts.find((contact) => { return contact._id === window.$nuxt.$route.params.id })
+    contactInfo: state => state.contacts.contact
   }),
 
   methods: {

--- a/pages/view/engagement/_id.vue
+++ b/pages/view/engagement/_id.vue
@@ -112,13 +112,18 @@ export default {
     EngShowContacts
   },
 
-  computed: mapState({
-    engagement: state => state.engagements.engagements.find((engagement) => { return engagement._id === window.$nuxt.$route.params.id })
-  }),
-  created() {
-    // eslint-disable-next-line no-console
-    console.log(this.engagement.contacts)
+  async fetch() {
+    try {
+      await this.$store.dispatch('engagements/fetchEngagement', this.$route.params.id)
+    } catch (e) {
+      // eslint-disable-next-line no-console
+      console.log('Error: ', e.response)
+    }
   },
+
+  computed: mapState({
+    engagement: state => state.engagements.engagement
+  }),
   methods: {
     goBack() {
       this.$router.back()


### PR DESCRIPTION
# Description

Allows deep navigation of contacts->engagements->contacts..etc starting from the Engagement or Contact search.

## Test Instructions

1. Navigate to the engagement or contact search pages and select a contact or engagement
1. In detail view, see related engagements or contacts and select one
1. In detail view, see related engagements or contacts and select one
1. etc.

## Help Requested

- If the client has no connection whatsoever, the error will return in the try/catch block of fetch() in _id.vue and log out to the console. We will likely want to show an error page in this case. Ideas for implementation would be appreciated.

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
