### PR TITLE
Styling and flow fixing. Branch: home-button-redirect

### DIFF
--- a/components/app/AppEngConToggle.vue
+++ b/components/app/AppEngConToggle.vue
@@ -40,10 +40,10 @@ export default {
       this.txtColorCon = 'black'
       this.bgColorCon = 'white'
       this.txtColorEng = 'white'
-      this.bgColorEng = '#2572b4'
+      this.bgColorEng = '#134164'
     } else {
       this.txtColorCon = 'white'
-      this.bgColorCon = '#2572b4'
+      this.bgColorCon = '#134164'
       this.txtColorEng = 'black'
       this.bgColorEng = 'white'
     }
@@ -53,13 +53,13 @@ export default {
       if (select) {
         this.isSelected = false
         this.txtColorCon = 'white'
-        this.bgColorCon = '#2572b4'
+        this.bgColorCon = '#134164'
         this.bgColorEng = 'white'
         this.txtColorEng = 'black'
       } else {
         this.txtColorCon = 'black'
         this.bgColorCon = 'white'
-        this.bgColorEng = '#2572b4'
+        this.bgColorEng = '#134164'
         this.txtColorEng = 'white'
         this.isSelected = true
       }

--- a/components/app/AppEngConToggle.vue
+++ b/components/app/AppEngConToggle.vue
@@ -40,10 +40,10 @@ export default {
       this.txtColorCon = 'black'
       this.bgColorCon = 'white'
       this.txtColorEng = 'white'
-      this.bgColorEng = '#134164'
+      this.bgColorEng = '#246880'
     } else {
       this.txtColorCon = 'white'
-      this.bgColorCon = '#134164'
+      this.bgColorCon = '#246880'
       this.txtColorEng = 'black'
       this.bgColorEng = 'white'
     }
@@ -53,13 +53,13 @@ export default {
       if (select) {
         this.isSelected = false
         this.txtColorCon = 'white'
-        this.bgColorCon = '#134164'
+        this.bgColorCon = '#246880'
         this.bgColorEng = 'white'
         this.txtColorEng = 'black'
       } else {
         this.txtColorCon = 'black'
         this.bgColorCon = 'white'
-        this.bgColorEng = '#134164'
+        this.bgColorEng = '#246880'
         this.txtColorEng = 'white'
         this.isSelected = true
       }

--- a/components/app/AppEngConToggle.vue
+++ b/components/app/AppEngConToggle.vue
@@ -1,0 +1,73 @@
+<template>
+  <div class="inline-flex pt-6">
+    <nuxt-link
+      class="left"
+      :style="{ color: txtColorEng, 'background-color': bgColorEng }"
+      :to="localePath(`/${ search?'search':'add' }/engagement`)"
+      @click.native="colorChange(true)"
+    >
+      Engagement
+    </nuxt-link>
+    <nuxt-link
+      class="right"
+      :style="{ color: txtColorCon, 'background-color': bgColorCon }"
+      :to="localePath(`/${ search?'search':'add' }/contact`)"
+      @click.native="colorChange(false)"
+    >
+      Contact
+    </nuxt-link>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'AppEngConToggle',
+  props: {
+    // eslint-disable-next-line vue/prop-name-casing
+    search: { type: Boolean, default: true }
+  },
+  data() {
+    return {
+      txtColorCon: '',
+      bgColorCon: '',
+      txtColorEng: '',
+      bgColorEng: '',
+      isSelected: true
+    }
+  },
+  created() {
+    if (this.$route.path.includes('engagement')) {
+      this.txtColorCon = 'black'
+      this.bgColorCon = 'white'
+      this.txtColorEng = 'white'
+      this.bgColorEng = '#2572b4'
+    } else {
+      this.txtColorCon = 'white'
+      this.bgColorCon = '#2572b4'
+      this.txtColorEng = 'black'
+      this.bgColorEng = 'white'
+    }
+  },
+  methods: {
+    colorChange(select) {
+      if (select) {
+        this.isSelected = false
+        this.txtColorCon = 'white'
+        this.bgColorCon = '#2572b4'
+        this.bgColorEng = 'white'
+        this.txtColorEng = 'black'
+      } else {
+        this.txtColorCon = 'black'
+        this.bgColorCon = 'white'
+        this.bgColorEng = '#2572b4'
+        this.txtColorEng = 'white'
+        this.isSelected = true
+      }
+    }
+  }
+}
+</script>
+
+<style>
+
+</style>

--- a/components/app/AppNavAdding.vue
+++ b/components/app/AppNavAdding.vue
@@ -10,67 +10,15 @@
         </p>
       </div>
     </div>
-    <div class="inline-flex pt-6">
-      <nuxt-link
-        class="left"
-        :style="{ color: txtColorCon, 'background-color': bgColorCon }"
-        :to="localePath('/add/contact')"
-        @click.native="colorChange(true)"
-      >
-        Contact
-      </nuxt-link>
-      <nuxt-link
-        class="right"
-        :style="{ color: txtColorEng, 'background-color': bgColorEng }"
-        :to="localePath('/add/engagement')"
-        @click.native="colorChange(false)"
-      >
-        Engagement
-      </nuxt-link>
-    </div>
+    <AppEngConToggle :search="false" />
   </div>
 </template>
 
 <script>
+import AppEngConToggle from '@/components/app/AppEngConToggle'
 export default {
-  data() {
-    return {
-      txtColorCon: '',
-      bgColorCon: '',
-      txtColorEng: '',
-      bgColorEng: '',
-      isSelected: true
-    }
-  },
-  created() {
-    if (this.$route.path.includes('engagement')) {
-      this.txtColorCon = 'black'
-      this.bgColorCon = 'white'
-      this.txtColorEng = 'white'
-      this.bgColorEng = '#2572b4'
-    } else {
-      this.txtColorCon = 'white'
-      this.bgColorCon = '#2572b4'
-      this.txtColorEng = 'black'
-      this.bgColorEng = 'white'
-    }
-  },
-  methods: {
-    colorChange(select) {
-      if (select) {
-        this.isSelected = false
-        this.txtColorCon = 'white'
-        this.bgColorCon = '#2572b4'
-        this.bgColorEng = 'white'
-        this.txtColorEng = 'black'
-      } else {
-        this.txtColorCon = 'black'
-        this.bgColorCon = 'white'
-        this.bgColorEng = '#2572b4'
-        this.txtColorEng = 'white'
-        this.isSelected = true
-      }
-    }
+  components: {
+    AppEngConToggle
   }
 }
 </script>

--- a/components/app/AppNavAdding.vue
+++ b/components/app/AppNavAdding.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="navContainer" class="ml-12">
-    <div class="mt-24">
+    <div class="mt-16">
       <h2 class="newAdd font-display">
         {{ $t('app.add') }}
       </h2>
@@ -26,8 +26,8 @@ export default {
 <style>
 .newAdd {
   font-weight: 600;
-  font-size: 48pt;
-  color: #246880;
+  font-size: 48px;
+  color: #426177;
 }
 .requireFields {
   font-weight: 700;

--- a/components/app/AppNavSearching.vue
+++ b/components/app/AppNavSearching.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="px-4">
+  <div>
     <div>
       <h2 class="searchHeader font-display">
         {{ $t('app.search') }}

--- a/components/app/AppNavSearching.vue
+++ b/components/app/AppNavSearching.vue
@@ -11,74 +11,20 @@
         </p>
       </div>
     </div>
-
     <AppFilterForm @filter="filterInformation" />
-
-    <div class="inline-flex pt-6">
-      <nuxt-link
-        class="left"
-        :style="{ color: txtColorCon, 'background-color': bgColorCon }"
-        :to="localePath('/search/contact')"
-        @click.native="colorChange(true)"
-      >
-        Contact
-      </nuxt-link>
-      <nuxt-link
-        class="right"
-        :style="{ color: txtColorEng, 'background-color': bgColorEng }"
-        :to="localePath('/search/engagement')"
-        @click.native="colorChange(false)"
-      >
-        Engagement
-      </nuxt-link>
-    </div>
+    <AppEngConToggle :search="true" />
   </div>
 </template>
 
 <script>
 import AppFilterForm from '@/components/app/AppFilterForm'
+import AppEngConToggle from '@/components/app/AppEngConToggle'
 export default {
   components: {
-    AppFilterForm
-  },
-  data() {
-    return {
-      txtColorCon: '',
-      bgColorCon: '',
-      txtColorEng: '',
-      bgColorEng: '',
-      isSelected: true
-    }
-  },
-  created() {
-    if (this.$route.path.includes('engagement')) {
-      this.txtColorCon = 'black'
-      this.bgColorCon = 'white'
-      this.txtColorEng = 'white'
-      this.bgColorEng = '#2572b4'
-    } else {
-      this.txtColorCon = 'white'
-      this.bgColorCon = '#2572b4'
-      this.txtColorEng = 'black'
-      this.bgColorEng = 'white'
-    }
+    AppFilterForm,
+    AppEngConToggle
   },
   methods: {
-    colorChange(select) {
-      if (select) {
-        this.isSelected = false
-        this.txtColorCon = 'white'
-        this.bgColorCon = '#2572b4'
-        this.bgColorEng = 'white'
-        this.txtColorEng = 'black'
-      } else {
-        this.txtColorCon = 'black'
-        this.bgColorCon = 'white'
-        this.bgColorEng = '#2572b4'
-        this.txtColorEng = 'white'
-        this.isSelected = true
-      }
-    },
     filterInformation(input) {
       this.$emit('filterResults', input)
     }

--- a/components/contact/ConShowEngagements.vue
+++ b/components/contact/ConShowEngagements.vue
@@ -124,7 +124,7 @@ export default {
   width: 56px;
 }
 .tag {
-  @apply bg-rmp-dk-orange text-white rounded-full px-4 py-1 ml-2;
+  @apply bg-rmp-lt-blue text-rmp-md-blue rounded-full px-4 py-1 ml-2;
 }
 @media (max-width: 768px) {
   .leftborder { @apply hidden; }

--- a/components/layout/AppHeader.vue
+++ b/components/layout/AppHeader.vue
@@ -23,7 +23,7 @@
     </div>
     <div id="blue-background" class="relative">
       <div class="flex justify-between absolute bottom-0 w-full px-5 py-3">
-        <nuxt-link :to="localePath('/')">
+        <nuxt-link :to="localePath('/search/engagement')">
           <img
             data-cy="home-button"
             src="@/assets/images/Home.svg"
@@ -31,8 +31,8 @@
             :alt="$t('header.homeAlt')"
           />
         </nuxt-link>
-        <span class="hidden sm:block pt-5 text-2xl">
-          Text placeholder
+        <span class="hidden pl-4 sm:block pt-5 text-center text-3xl font-bold rmp">
+          {{ $t('app.dts') }}
         </span>
         <div id="userInfo">
           <div class="flex p-6">
@@ -82,6 +82,9 @@ export default {
   background-color: #bbb;
   border-radius: 50%;
   display: inline-block;
+}
+.rmp{
+  color: #D87C4F;
 }
 @media (max-width: 420px) {
   #canadaImg {

--- a/components/layout/AppNavBtn.vue
+++ b/components/layout/AppNavBtn.vue
@@ -38,17 +38,17 @@ export default {
   },
   created() {
     if (this.$route.path.includes('add')) {
-      this.txtColorSearch = '#D87C4F'
-      this.bgColorSearch = 'white'
-      this.txtColorAdd = 'white'
-      this.bgColorAdd = '#D87C4F'
-      this.boxShadowAdd = 'none'
-      this.boxShadowSearch = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
-    } else {
       this.txtColorSearch = 'white'
       this.bgColorSearch = '#D87C4F'
       this.txtColorAdd = '#D87C4F'
       this.bgColorAdd = 'white'
+      this.boxShadowAdd = 'none'
+      this.boxShadowSearch = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
+    } else {
+      this.txtColorSearch = '#D87C4F'
+      this.bgColorSearch = 'white'
+      this.txtColorAdd = 'white'
+      this.bgColorAdd = '#D87C4F'
       this.boxShadowAdd = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
       this.boxShadowSearch = 'none'
     }
@@ -56,18 +56,18 @@ export default {
   methods: {
     colorChange(select) {
       if (select) {
-        this.txtColorAdd = '#D87C4F'
-        this.bgColorAdd = 'white'
-        this.bgColorSearch = '#D87C4F'
-        this.txtColorSearch = 'white'
-        this.boxShadowAdd = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
-        this.boxShadowSearch = 'none'
-        this.isSelected = true
-      } else {
         this.txtColorAdd = 'white'
         this.bgColorAdd = '#D87C4F'
         this.bgColorSearch = 'white'
         this.txtColorSearch = '#D87C4F'
+        this.boxShadowAdd = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
+        this.boxShadowSearch = 'none'
+        this.isSelected = true
+      } else {
+        this.txtColorAdd = '#D87C4F'
+        this.bgColorAdd = 'white'
+        this.bgColorSearch = '#D87C4F'
+        this.txtColorSearch = 'white'
         this.boxShadowAdd = 'none'
         this.boxShadowSearch = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
         this.isSelected = false
@@ -83,7 +83,7 @@ export default {
 }
 .switch {
   padding: 25px;
-  @apply cursor-pointer text-3xl font-display font-bold text-center w-full;
+  @apply cursor-pointer text-3xl font-display font-bold text-center w-full border;
 }
 .not-selected{
   color: white;

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -34,7 +34,7 @@ export default {
 
   // app
   app: {
-    dts: 'dts-rmp',
+    dts: 'Relationship Management Portal',
     welcome: 'relationship management portal proof of concept!',
     search: 'Search',
     add: 'Add new'

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -34,7 +34,7 @@ export default {
 
   // app
   app: {
-    dts: 'dts-rmp-French',
+    dts: 'Portail de Gestion des Relations',
     welcome: 'relationship management portal proof of concept!',
     search: 'Recherche',
     add: 'Ajouter'

--- a/pages/search/contact.vue
+++ b/pages/search/contact.vue
@@ -1,26 +1,28 @@
 <template>
   <div class="main pt-1 xl:mx-16">
-    <AppNavSearching class="my-16" @filterResults="filter" />
-    <div class="text-sm font-body font-semibold">
-      {{ totalRecords }} results
-    </div>
-    <!-- Loop through contacts here. look at 'search/engagement' for guidance -->
-    <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
-      <!-- Still requires "last" property for last engagement to be setup, discussion on "date" property TODO -->
-      <EngShowContacts
-        v-for="(con, index) in filteredContacts"
-        :id="con._id"
-        :key="index"
-        :index="index"
-        :name="con.keyContactName"
-        :orgname="con.orgName"
-        :title="con.keyContactTitle"
-        :phone="con.keyContactPhone"
-        :email="con.keyContactEmail"
-        :last="con.engagements[0] ? con.engagements[0].type : undefined"
-        :date="con.engagements[0] ? con.engagements[0].date.substring(0, 10) : undefined"
-        :number="con.engagements[0] ? con.engagements[0].numParticipants : undefined"
-      />
+    <div class="ml-12">
+      <AppNavSearching class="my-16" @filterResults="filter" />
+      <div class="text-sm font-body font-semibold">
+        {{ totalRecords }} results
+      </div>
+      <!-- Loop through contacts here. look at 'search/engagement' for guidance -->
+      <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
+        <!-- Still requires "last" property for last engagement to be setup, discussion on "date" property TODO -->
+        <EngShowContacts
+          v-for="(con, index) in filteredContacts"
+          :id="con._id"
+          :key="index"
+          :index="index"
+          :name="con.keyContactName"
+          :orgname="con.orgName"
+          :title="con.keyContactTitle"
+          :phone="con.keyContactPhone"
+          :email="con.keyContactEmail"
+          :last="con.engagements[0] ? con.engagements[0].type : undefined"
+          :date="con.engagements[0] ? con.engagements[0].date.substring(0, 10) : undefined"
+          :number="con.engagements[0] ? con.engagements[0].numParticipants : undefined"
+        />
+      </div>
     </div>
   </div>
 </template>

--- a/pages/search/engagement.vue
+++ b/pages/search/engagement.vue
@@ -1,24 +1,26 @@
 <template>
   <div class="main pt-1 xl:mx-16">
-    <AppNavSearching class="my-16" @filterResults="filter" />
+    <div class="ml-12">
+      <AppNavSearching class="my-16" @filterResults="filter" />
 
-    <div class="text-sm font-body font-semibold">
-      {{ totalRecords }} results
-    </div>
+      <div class="text-sm font-body font-semibold">
+        {{ totalRecords }} results
+      </div>
 
-    <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
-      <ConShowEngagaments
-        v-for="(eng, index) in filteredEngagements"
-        :id="eng._id"
-        :key="index"
-        :index="index"
-        :type="eng.type"
-        :contacts="eng.contacts"
-        :tags="eng.tags"
-        :date="(eng.date).substring(0, 10)"
-        :description="eng.description"
-        :number="eng.numParticipants"
-      />
+      <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
+        <ConShowEngagaments
+          v-for="(eng, index) in filteredEngagements"
+          :id="eng._id"
+          :key="index"
+          :index="index"
+          :type="eng.type"
+          :contacts="eng.contacts"
+          :tags="eng.tags"
+          :date="(eng.date).substring(0, 10)"
+          :description="eng.description"
+          :number="eng.numParticipants"
+        />
+      </div>
     </div>
   </div>
 </template>


### PR DESCRIPTION
# Description

A few Changes:
1. The header text placeholder has been change to RMP for French and English.
2. Home button redirects to search/engagement.
3. AppNavButton is orange when selected. (Primary colour for selected)
4. Created component for the blue toggle between engagement and contacts.
5. Since engagement is default, it is now to the left.

## Test Instructions

Test respectively:
1. Toggle French and English and see the header title change.
2. Click home button and it should bring you to 'search/engagement'. (NOTICE: the buttons should be selected 
    for search and engagement.)
3. Navigate through 'Search Contacts and Engagement' to 'Add Contacts and engagements' The colour should 
    change to orange as selected.
4. & 5. Test the blue toggle and confirm that the right page is displayed. Engagement should be on the left now. 

## Help Requested


## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
