### PR TITLE
Added dotenv for axios baseURL configuration in nuxt.config.js

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -121,10 +121,6 @@ module.exports = {
     // API middleware
     '~/api/index'
   ],
-  // Ensure client side variables will be the same as the server
-  env: {
-    baseURL: process.env.baseURL || 'http://localhost:3000'
-  },
   /*
    ** Axios module configuration
    ** See https://axios.nuxtjs.org/options

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -41,12 +41,12 @@ module.exports = {
     }
   ],
   /*
-   ** Nuxt.js dev-modules
-   */
+  ** Nuxt.js dev-modules
+  */
   buildModules: ['@nuxtjs/eslint-module', '@nuxtjs/tailwindcss'],
   /*
-   ** Nuxt.js modules
-   */
+  ** Nuxt.js modules
+  */
   modules: [
     // Doc: https://axios.nuxtjs.org/usage
     '@nuxtjs/axios',
@@ -57,6 +57,13 @@ module.exports = {
     // https://nuxt-community.github.io/nuxt-i18n/
     'nuxt-i18n'
   ],
+  /*
+   ** Axios module configuration
+   ** See https://axios.nuxtjs.org/options
+   */
+  axios: {
+    baseURL: process.env.baseURL || 'http://localhost:3000'
+  },
   i18n: {
     locales: [
       {
@@ -121,13 +128,6 @@ module.exports = {
     // API middleware
     '~/api/index'
   ],
-  /*
-   ** Axios module configuration
-   ** See https://axios.nuxtjs.org/options
-   */
-  axios: {
-    baseURL: process.env.baseURL || 'http://localhost:3000'
-  },
   /*
    ** Build configuration
    */

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,3 +1,6 @@
+import dotenv from 'dotenv'
+dotenv.config()
+
 module.exports = {
   mode: 'universal',
   /*
@@ -113,10 +116,22 @@ module.exports = {
       home: '/welcome'
     }
   },
+
   serverMiddleware: [
     // API middleware
-    '~/api/index.js'
+    '~/api/index'
   ],
+  // Ensure client side variables will be the same as the server
+  env: {
+    baseURL: process.env.baseURL || 'http://localhost:3000'
+  },
+  /*
+   ** Axios module configuration
+   ** See https://axios.nuxtjs.org/options
+   */
+  axios: {
+    baseURL: process.env.baseURL || 'http://localhost:3000'
+  },
   /*
    ** Build configuration
    */

--- a/store/engagements.js
+++ b/store/engagements.js
@@ -14,7 +14,6 @@ export const mutations = {
 
 export const actions = {
   fetchEngagements({ commit }) {
-    console.log(this.$axios.defaults)
     return this.$axios.get('/api/engagement/engagements')
       .then((response) => {
         commit('SET_ENGAGEMENTS', response.data)

--- a/store/engagements.js
+++ b/store/engagements.js
@@ -14,6 +14,7 @@ export const mutations = {
 
 export const actions = {
   fetchEngagements({ commit }) {
+    console.log(this.$axios.defaults)
     return this.$axios.get('/api/engagement/engagements')
       .then((response) => {
         commit('SET_ENGAGEMENTS', response.data)


### PR DESCRIPTION
# Description

Added dotenv to the nuxt.config. This ensures that both client and server use the same baseURL value as defined in your .env file `baseURL` variable. Without this, `process.env.baseURL` in the nuxt.config.js was always undefined in both dev and prod builds and was defaulted by axios to localhost:3000 regardless of your .env variable value. 

## Test Instructions

1. Add the variable and value `baseURL=http://localhost:3000` to your .env file
1. npm run mongodb
1. npm run seed
1. npm run dev
1. see that navigating to search returns data
1. close dev instance
1. change the variable and value `baseURL=http://localhost:3000` to `baseURL=http://localhost:4567`
1. npm run dev
1. see a connection refused error in the console when navigating to the search
1. revert variable and value to `baseURL=http://localhost:3000` for development

## Help Requested

- If this doesn't fix the deployed app, then it is a problem with the variables or lack thereof being passed into the application in the pipeline.
