### PR TITLE
Changed Engagements schema, 2 comments generated in seeder

### DIFF
--- a/api/models/engagement.js
+++ b/api/models/engagement.js
@@ -8,7 +8,7 @@ const EngagementSchema = new Schema({
   numParticipants: { type: Number, required: true },
   contacts: [{ type: Schema.Types.ObjectId, required: true, ref: 'Contact' }],
   policyProgram: { type: String },
-  comments: [{ user: String, content: String, date: Date }],
+  comments: [{ type: String }],
   tags: [{ type: String }]
 })
 

--- a/tools/seeder/seeder.js
+++ b/tools/seeder/seeder.js
@@ -67,7 +67,9 @@ const populateDatabase = async() => {
       numParticipants: Randomizers.randomInt(2, 5),
       contacts: [],
       policyProgram: Randomizers.randomString(12),
-      comments: [],
+      comments: [`${Randomizers.randomString(6)} ${Randomizers.randomString(3)} ${Randomizers.randomString(5)} ${Randomizers.randomString(8)}`,
+      `${Randomizers.randomString(6)} ${Randomizers.randomString(3)} ${Randomizers.randomString(5)} ${Randomizers.randomString(8)}`
+      ],
       tags: Randomizers.randomTagArray()
     })
   }


### PR DESCRIPTION
# Description

[Add engagement comments to seeding](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/241?kanban-status=72)

Changing the Engagements schema comments property to take an array of strings. Seeder will now populate each engagement with 2 comments.

# Story Acceptance Criteria

[#109 View Engagement info detail view](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/us/109?milestone=20)

User performs Engagement search and clicks a engagement from the search results, all engagement details are displayed
User clicks "Back to Results" button and returns to Engagement search results
Mobile/Web layout match mockups
Exclusions:

No "Edit Engagement" button support

## Test Instructions

1. npm run mongodb
1. npm run seed
1. use Robo3T, Studio3T, Postman or your browser to see the comments under each Engagement document
