### PR TITLE
#240 home nav buttons

### DIFF
--- a/components/layout/AppNavBtn.vue
+++ b/components/layout/AppNavBtn.vue
@@ -4,18 +4,16 @@
       <nuxt-link
         :to="localePath('/search/engagement')"
         data-cy="search-nav"
-        class="switch underline"
-        :style="{ color: txtColorAdd, 'background-color': bgColorAdd, 'box-shadow': boxShadowAdd }"
-        @click.native="colorChange(true)"
+        class="nav-link"
+        :class="{ 'nav-link-selected' : currentPath.includes('search')}"
       >
         {{ $t('NavBtn.SearchConEn') }}
       </nuxt-link>
       <nuxt-link
         :to="localePath('/add/engagement')"
         data-cy="add-nav"
-        class="switch underline"
-        :style="{ color: txtColorSearch, 'background-color': bgColorSearch, 'box-shadow': boxShadowSearch }"
-        @click.native="colorChange(false)"
+        class="nav-link"
+        :class="{ 'nav-link-selected' : currentPath.includes('add')}"
       >
         {{ $t('NavBtn.AddConEn') }}
       </nuxt-link>
@@ -25,82 +23,39 @@
 
 <script>
 export default {
-  data() {
-    return {
-      txtColorAdd: '#D87C4F',
-      bgColorAdd: 'white',
-      txtColorSearch: 'white',
-      bgColorSearch: '#D87C4F',
-      boxShadowAdd: 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)',
-      boxShadowSearch: 'none',
-      isSelected: Boolean
-    }
-  },
-  created() {
-    if (this.$route.path.includes('add')) {
-      this.txtColorSearch = 'white'
-      this.bgColorSearch = '#D87C4F'
-      this.txtColorAdd = '#D87C4F'
-      this.bgColorAdd = 'white'
-      this.boxShadowAdd = 'none'
-      this.boxShadowSearch = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
-    } else {
-      this.txtColorSearch = '#D87C4F'
-      this.bgColorSearch = 'white'
-      this.txtColorAdd = 'white'
-      this.bgColorAdd = '#D87C4F'
-      this.boxShadowAdd = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
-      this.boxShadowSearch = 'none'
-    }
-  },
-  methods: {
-    colorChange(select) {
-      if (select) {
-        this.txtColorAdd = 'white'
-        this.bgColorAdd = '#D87C4F'
-        this.bgColorSearch = 'white'
-        this.txtColorSearch = '#D87C4F'
-        this.boxShadowAdd = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
-        this.boxShadowSearch = 'none'
-        this.isSelected = true
-      } else {
-        this.txtColorAdd = '#D87C4F'
-        this.bgColorAdd = 'white'
-        this.bgColorSearch = '#D87C4F'
-        this.txtColorSearch = 'white'
-        this.boxShadowAdd = 'none'
-        this.boxShadowSearch = 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)'
-        this.isSelected = false
-      }
+  computed: {
+    currentPath() {
+      return this.$route.path
     }
   }
 }
 </script>
 
 <style scoped>
-.switch:focus {
-  outline: none;
-}
-.switch {
-  padding: 25px;
-  @apply cursor-pointer text-3xl font-display font-bold text-center w-full border;
-}
-.not-selected{
-  color: white;
-  background-color: #D87C4F;
-  box-shadow: none;
-
-}
-.selected{
+.nav-link {
   color: #D87C4F;
   background-color: white;
+  padding: 25px;
+  box-shadow: none;
+  @apply cursor-pointer text-3xl font-display font-bold text-center w-full border underline;
+}
+
+.nav-link:focus {
+  outline: none;
+}
+
+.nav-link-selected {
+  color: white;
+  background-color: #D87C4F;
   box-shadow: 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)';
 }
+
 @media (max-width: 660px) {
   #btna {
     @apply flex-col w-auto;
   }
 }
+
 @media (max-width: 660px) {
   #h2Text {
     @apply text-2xl;

--- a/components/layout/AppNavBtn.vue
+++ b/components/layout/AppNavBtn.vue
@@ -36,7 +36,6 @@ export default {
   color: #D87C4F;
   background-color: white;
   padding: 25px;
-  box-shadow: none;
   @apply cursor-pointer text-3xl font-display font-bold text-center w-full border underline;
 }
 
@@ -47,7 +46,7 @@ export default {
 .nav-link-selected {
   color: white;
   background-color: #D87C4F;
-  box-shadow: 'inset 0 10px 30px rgba(0, 0, 0, 0.5), 0 10px rgba(255, 255, 255, 0.5)';
+  box-shadow: inset 0 10px 30px 0 rgba(0, 0, 0, 0.5)
 }
 
 @media (max-width: 660px) {


### PR DESCRIPTION
# Description

[#240 [BUG] Home nav buttons with the home button. See description.](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/240?kanban-status=72)

This is a fix for a minor logic error. If you navigated to the add tab, then pressed the home button, the search page would render, but the nav bar would not update (the wrong `nuxt-link` element would stay highlighted)

# Story Acceptance Criteria

[#240 [BUG] Home nav buttons with the home button. See description.](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/240?kanban-status=72)
BUG: No AC from PO

## Test Instructions

1. From the default page, navigate to the 'Add contacts & engagements' tab by clicking the 'Add contacts & engagements' button in the nav bar 
1. Press the home button (Picture of a house in the top left of the page)
1. Once the home page (Search contacts & engagements) renders, the nav bar should highlight the proper page. (The one you are currently on) 

## Help Requested

- Any CSS tips would be appreciated

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
