### PR TITLE
Stopped showing nav bar on detailed view pages

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -17,7 +17,7 @@
 export default {
   computed: {
     shouldDisplayNav() {
-      return !this.$route.path.includes('view')
+      return !(this.$route.path.includes('view') || this.$route.path.includes('edit'))
     }
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -2,7 +2,7 @@
   <div class="main-container">
     <header>
       <AppHeader />
-      <AppNavBtn />
+      <AppNavBtn v-if="shouldDisplayNav" />
     </header>
     <main>
       <!-- <TitleComponent /> -->
@@ -15,8 +15,13 @@
   </div>
 </template>
 <script>
-// import TitleComponent from '@/components/TitleComponent.vue'
-export default {}
+export default {
+  computed: {
+    shouldDisplayNav() {
+      return !this.$route.path.includes('view')
+    }
+  }
+}
 </script>
 <style>
 html {

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -5,7 +5,6 @@
       <AppNavBtn v-if="shouldDisplayNav" />
     </header>
     <main>
-      <!-- <TitleComponent /> -->
       <nuxt />
     </main>
     <footer>


### PR DESCRIPTION
# Description

[[BUG] Only display Nav bar at appropriate times (See design)](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/258?kanban-status=74)

Changed the behaviour of the navigation bar to dynamically render based on weather or not your looking at a detailed view.

# Story Acceptance Criteria

[238 Styling Updates](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/us/238?milestone=20)

General fixes. No written AC. Please compare with design and notes on Taiga task: [[BUG] Only display Nav bar at appropriate times (See design)](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/258?kanban-status=74)

## Test Instructions

1. Open the design and check the detailed contacts and engagements page to see the intended behaviour (No app nav bar on these pages)
1. launch the app, navigate to 'Search contacts & engagements'
1. Compare the missing app nav bar to the missing app nav bar in the design
1. Note that this feature was solely to fix this behaviour, not to update styling on engagement page. Review accordingly.

## Help Requested

¯\_(ツ)_/¯

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
