### PR TITLE
 contact forms mobile version and btn size updated

### DIFF
--- a/components/app/AppNavAdding.vue
+++ b/components/app/AppNavAdding.vue
@@ -74,4 +74,9 @@ export default {
   font-family: 'Noto Sans', 'DejaVu Serif', 'Roboto slab', 'sans-serif',
     'Helvetica Neue';
 }
+@media screen and (max-width: 768px) {
+  h1 { font-size: 28px; }
+  h2 { font-size: 18px; }
+  h3 { font-size: 16px; }
+}
 </style>

--- a/components/contact/ConViewFields.vue
+++ b/components/contact/ConViewFields.vue
@@ -25,5 +25,7 @@ export default {
 .Label {
   @apply font-bold text-rmp-orange text-xl;
 }
-
+@media screen and (max-width: 768px) {
+  .Label { font-size: 16px !important; }
+}
 </style>

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="contactForm font-body mt-8 mx-12">
+  <div class="contactForm font-body mt-8 mx-2">
     <div>
-      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list">
+      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list md:w-full">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">
           {{ $t('contactValidation.errorListTitle') }}
         </h2>
@@ -24,8 +24,8 @@
         </p>
       </div>
 
-      <div class="flex mb-4">
-        <div class="w-5/12 margins">
+      <div class="md:flex flex-wrap  mb-4 ">
+        <div class=" md:w-5/12 margins ">
           <select
             v-model="contactInfo.type"
             class="formSelect"
@@ -52,8 +52,8 @@
       </h2>
 
       <form @submit.prevent="submitForm(contactInfo)">
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel orange" for="keyContactName">
               {{ $t('contact.keyContactName') }}
             </label>
@@ -76,7 +76,7 @@
               {{ $t('contactValidation.required') }}
             </p>
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel orange" for="keyContactTitle">
               {{ $t('contact.keyContactTitle') }}
             </label>
@@ -101,8 +101,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactAddress">
               {{ $t('contact.address') }}
             </label>
@@ -114,7 +114,7 @@
               :placeholder="$t('contact.address')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactAddress2">
               {{ $t('contact.address2') }}
             </label>
@@ -128,8 +128,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactCity">
               {{ $t('contact.city') }}
             </label>
@@ -141,7 +141,7 @@
               :placeholder="$t('contact.city')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactProv">
               {{ $t('contact.provState') }}
             </label>
@@ -155,8 +155,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactCountry">
               {{ $t('contact.country') }}
             </label>
@@ -168,7 +168,7 @@
               :placeholder="$t('contact.country')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactPostal">
               {{ $t('contact.postal') }}
             </label>
@@ -182,8 +182,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel orange" for="keyContactEmail">
               {{ $t('contact.keyContactEmail') }}
             </label>
@@ -215,7 +215,7 @@
               {{ $t('contactValidation.invalidEmail') }}
             </p>
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactPhone">
               {{ $t('contact.phone') }}
             </label>
@@ -233,8 +233,8 @@
           {{ $t('contact.organization') }}
         </h2>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgName">
               {{ $t('contact.orgName') }}
             </label>
@@ -246,7 +246,7 @@
               :placeholder="$t('contact.orgName')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgWebsite">
               {{ $t('contact.orgWebsite') }}
             </label>
@@ -260,8 +260,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12  margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgAddress">
               {{ $t('contact.address') }}
             </label>
@@ -273,7 +273,7 @@
               :placeholder="$t('contact.address')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgAddress2">
               {{ $t('contact.address2') }}
             </label>
@@ -287,8 +287,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12  margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgCity">
               {{ $t('contact.city') }}
             </label>
@@ -300,7 +300,7 @@
               :placeholder="$t('contact.city')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgProvState">
               {{ $t('contact.provState') }}
             </label>
@@ -314,8 +314,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12  margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgCountry">
               {{ $t('contact.country') }}
             </label>
@@ -327,7 +327,7 @@
               :placeholder="$t('contact.country')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="keyContactPostal">
               {{ $t('contact.postal') }}
             </label>
@@ -341,8 +341,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgEmail">
               {{ $t('contact.orgEmail') }}
             </label>
@@ -354,7 +354,7 @@
               :placeholder="$t('contact.orgEmail')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="orgPhone">
               {{ $t('contact.phone') }}
             </label>
@@ -368,8 +368,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="department">
               {{ $t('contact.department') }}
             </label>
@@ -381,7 +381,7 @@
               :placeholder="$t('contact.department')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="branch">
               {{ $t('contact.branch') }}
             </label>
@@ -395,8 +395,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="directorate">
               {{ $t('contact.directorate') }}
             </label>
@@ -409,7 +409,7 @@
             />
           </div>
 
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="provTerritory">
               {{ $t('contact.provTerritory') }}
             </label>
@@ -465,7 +465,7 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
+        <div class="md:flex flex-wrap  mb-4">
           <div class=" w-auto margins">
             <label class="formLabel" for="orgSector">
               {{ $t('contact.orgSector') }}
@@ -495,8 +495,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="contributionRefNo">
               {{ $t('contact.contrib') }}
             </label>
@@ -508,7 +508,7 @@
               :placeholder="$t('contact.contrib')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="serviceContrNo">
               {{ $t('contact.service') }}
             </label>
@@ -522,8 +522,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class="md:flex flex-wrap  mb-4">
+          <div class=" md:w-5/12 margins">
             <label class="formLabel" for="onStandingOffer">
               {{ $t('contact.standing') }}
             </label>
@@ -553,13 +553,13 @@
           </span>
         </div>
 
-        <div class="flex justify-start mb-4">
-          <div class="w-3/12 margins">
+        <div class="md:flex flex-wrap justify-start mb-4">
+          <div class=" md:w-4/12 margins">
             <AppButton custom_style="btn-cancel" data_cypress="cancelButton" type="button" @click="goBack">
               {{ $t('contact.cancel') }}
             </AppButton>
           </div>
-          <div class="w-3/12 margins">
+          <div class=" md:w-4/12 margins">
             <AppButton custom_style="btn-extra" data_cypress="submitButton">
               {{ $t('contact.save') }}
             </AppButton>
@@ -735,7 +735,6 @@ export default {
 
 <style scoped>
 .contactForm {
-  width: 1200px;
   @apply bg-white text-black;
 }
 .title {
@@ -763,13 +762,13 @@ export default {
   @apply outline-none border-blue-500;
 }
 .margins {
-  @apply px-1 py-2 m-2;
+  @apply py-2 mx-2 my-1;
 }
 .btn-cancel {
-  @apply justify-start bg-gray-300 w-11/12 text-black h-12;
+  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12;
 }
 .btn-extra {
-  @apply w-11/12 h-12 justify-start;
+  @apply w-full h-12 mt-2 justify-start;
 }
 .messageBox {
   font-size: 18px !important;

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -790,4 +790,9 @@ export default {
   background-color: rgba(255, 0, 0, 0.1);
   @apply border border-red-500;
 }
+@media screen and (max-width: 768px) {
+  h1 { font-size: 28px; }
+  h2 { font-size: 18px; }
+  h3 { font-size: 16px; }
+}
 </style>

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="contactForm font-body mt-8 mx-12">
     <div>
-      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list">
+      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list md:w-full">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">
           {{ $t('contactValidation.errorListTitle') }}
         </h2>
@@ -24,8 +24,8 @@
         </p>
       </div>
 
-      <div class="flex mb-4">
-        <div class="w-5/12 margins">
+      <div class="md:flex flex-wrap mb-4">
+        <div class=" md:w-5/12 margins ">
           <select
             v-model="contactInfo.type"
             class="formSelect"
@@ -52,8 +52,8 @@
       </h2>
 
       <form @submit.prevent="submitForm(contactInfo)">
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel orange" for="keyContactName">
               {{ $t('contact.keyContactName') }}
             </label>
@@ -76,7 +76,7 @@
               {{ $t('contactValidation.required') }}
             </p>
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel orange" for="keyContactTitle">
               {{ $t('contact.keyContactTitle') }}
             </label>
@@ -101,8 +101,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactAddress">
               {{ $t('contact.address') }}
             </label>
@@ -114,7 +114,7 @@
               :placeholder="$t('contact.address')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactAddress2">
               {{ $t('contact.address2') }}
             </label>
@@ -128,8 +128,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactCity">
               {{ $t('contact.city') }}
             </label>
@@ -141,7 +141,7 @@
               :placeholder="$t('contact.city')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactProv">
               {{ $t('contact.provState') }}
             </label>
@@ -155,8 +155,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactCountry">
               {{ $t('contact.country') }}
             </label>
@@ -168,7 +168,7 @@
               :placeholder="$t('contact.country')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactPostal">
               {{ $t('contact.postal') }}
             </label>
@@ -182,8 +182,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel orange" for="keyContactEmail">
               {{ $t('contact.keyContactEmail') }}
             </label>
@@ -215,7 +215,7 @@
               {{ $t('contactValidation.invalidEmail') }}
             </p>
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactPhone">
               {{ $t('contact.phone') }}
             </label>
@@ -233,8 +233,8 @@
           {{ $t('contact.organization') }}
         </h2>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="orgName">
               {{ $t('contact.orgName') }}
             </label>
@@ -246,7 +246,7 @@
               :placeholder="$t('contact.orgName')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="orgWebsite">
               {{ $t('contact.orgWebsite') }}
             </label>
@@ -260,7 +260,7 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
+        <div class=" md:flex flex-wrap mb-4 ">
           <div class="w-5/12  margins">
             <label class="formLabel" for="orgAddress">
               {{ $t('contact.address') }}
@@ -273,7 +273,7 @@
               :placeholder="$t('contact.address')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="orgAddress2">
               {{ $t('contact.address2') }}
             </label>
@@ -287,7 +287,7 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
+        <div class=" md:flex flex-wrap mb-4 ">
           <div class="w-5/12  margins">
             <label class="formLabel" for="orgCity">
               {{ $t('contact.city') }}
@@ -300,7 +300,7 @@
               :placeholder="$t('contact.city')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="orgProvState">
               {{ $t('contact.provState') }}
             </label>
@@ -314,7 +314,7 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
+        <div class=" md:flex flex-wrap mb-4 ">
           <div class="w-5/12  margins">
             <label class="formLabel" for="orgCountry">
               {{ $t('contact.country') }}
@@ -327,7 +327,7 @@
               :placeholder="$t('contact.country')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="keyContactPostal">
               {{ $t('contact.postal') }}
             </label>
@@ -341,8 +341,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="orgEmail">
               {{ $t('contact.orgEmail') }}
             </label>
@@ -354,7 +354,7 @@
               :placeholder="$t('contact.orgEmail')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="orgPhone">
               {{ $t('contact.phone') }}
             </label>
@@ -368,8 +368,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="department">
               {{ $t('contact.department') }}
             </label>
@@ -381,7 +381,7 @@
               :placeholder="$t('contact.department')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="branch">
               {{ $t('contact.branch') }}
             </label>
@@ -395,8 +395,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="directorate">
               {{ $t('contact.directorate') }}
             </label>
@@ -409,7 +409,7 @@
             />
           </div>
 
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="provTerritory">
               {{ $t('contact.provTerritory') }}
             </label>
@@ -465,7 +465,7 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
+        <div class=" md:flex flex-wrap mb-4 ">
           <div class=" w-auto margins">
             <label class="formLabel" for="orgSector">
               {{ $t('contact.orgSector') }}
@@ -495,8 +495,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="contributionRefNo">
               {{ $t('contact.contrib') }}
             </label>
@@ -508,7 +508,7 @@
               :placeholder="$t('contact.contrib')"
             />
           </div>
-          <div class="w-5/12 margins">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="serviceContrNo">
               {{ $t('contact.service') }}
             </label>
@@ -522,8 +522,8 @@
           </div>
         </div>
 
-        <div class="flex mb-4">
-          <div class="w-5/12 margins">
+        <div class=" md:flex flex-wrap mb-4 ">
+          <div class=" md:w-5/12 margins ">
             <label class="formLabel" for="onStandingOffer">
               {{ $t('contact.standing') }}
             </label>
@@ -553,13 +553,13 @@
           </span>
         </div>
 
-        <div class="flex justify-start mb-4">
-          <div class="w-3/12 margins">
+        <div class=" md:flex flex-wrap justify-start mb-4">
+          <div class=" md:w-4/12 margins">
             <AppButton custom_style="btn-cancel" data_cypress="cancelButton" type="button" @click="goBack">
               {{ $t('contact.cancel') }}
             </AppButton>
           </div>
-          <div class="w-3/12 margins">
+          <div class=" md:w-4/12 margins">
             <AppButton custom_style="btn-extra" data_cypress="submitButton">
               {{ $t('contact.save') }}
             </AppButton>
@@ -752,7 +752,6 @@ export default {
 
 <style scoped>
 .contactForm {
-  width: 1200px;
   @apply bg-white text-black;
 }
 .title {
@@ -780,13 +779,13 @@ export default {
   @apply outline-none border-blue-500;
 }
 .margins {
-  @apply px-1 py-2 m-2;
+  @apply py-2 mx-2 my-1;
 }
 .btn-cancel {
-  @apply justify-start bg-gray-300 w-11/12 text-black h-12;
+  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12;
 }
 .btn-extra {
-  @apply w-11/12 h-12 justify-start;
+  @apply w-full h-12 mt-2 justify-start;
 }
 .messageBox {
   font-size: 18px !important;

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -807,4 +807,9 @@ export default {
   background-color: rgba(255, 0, 0, 0.1);
   @apply border border-red-500;
 }
+@media screen and (max-width: 768px) {
+  h1 { font-size: 28px; }
+  h2 { font-size: 18px; }
+  h3 { font-size: 16px; }
+}
 </style>

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -205,13 +205,13 @@
         </span>
       </div>
 
-      <div class="flex justify-start mb-12">
-        <div class="w-3/12 margins">
+      <div class="md:flex flex-wrap justify-start mb-12">
+        <div class=" md:w-4/12 margins">
           <AppButton class="font-display" custom_style="btn-cancel" data_cypress="formButton">
             {{ $t('engagement.cancel') }}
           </AppButton>
         </div>
-        <div class="w-3/12 margins">
+        <div class=" md:w-4/12 margins">
           <AppButton class="font-display" custom_style="btn-extra" data_cypress="formButton">
             {{ $t('engagement.save') }}
           </AppButton>
@@ -341,10 +341,10 @@ export default {
   @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-4xl pt-4;
 }
 .btn-extra {
-  @apply w-11/12 h-12 justify-start;
+  @apply w-full mt-2 h-12 justify-start;
 }
 .btn-cancel {
-  @apply justify-start bg-gray-300 w-11/12 text-black h-12;
+  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12;
 }
 .formLabel {
   @apply font-bold;

--- a/components/engagement/EngViewFields.vue
+++ b/components/engagement/EngViewFields.vue
@@ -25,5 +25,7 @@ export default {
 .Label {
   @apply font-bold text-rmp-orange text-xl;
 }
-
+@media screen and (max-width: 768px) {
+  .Label { font-size: 16px !important; }
+}
 </style>

--- a/pages/view/contact/_id.vue
+++ b/pages/view/contact/_id.vue
@@ -1,57 +1,64 @@
 <template>
-  <div class="contactForm">
-    <h1 class="title">
+  <div class="contactForm font-body mt-8 mx-2">
+    <h1 class="title pb-6">
       {{ $t('contact.contact') }}
     </h1>
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class="md:w-5/12 margins">
         <ConViewFields label="keyContactName">
           {{ contactInfo.keyContactName }}
         </ConViewFields>
       </div>
-      <div class="w-5/12 margins">
+      <div class="md:w-5/12 margins">
         <ConViewFields label="phone">
           {{ contactInfo.keyContactPhone }}
         </ConViewFields>
       </div>
     </div>
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class=" md:w-5/12 margins ">
         <ConViewFields label="type">
           {{ contactInfo.type }}
         </ConViewFields>
       </div>
-      <div class="w-5/12 margins">
+      <div class=" md:w-5/12 margins ">
         <ConViewFields label="keyContactEmail">
           {{ contactInfo.keyContactEmail }}
         </ConViewFields>
       </div>
     </div>
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class=" md:w-5/12 margins ">
         <ConViewFields label="address">
           {{ contactInfo.keyContactAddress }}
         </ConViewFields>
       </div>
     </div>
+
     <h2 class="title">
       {{ $t('contact.organization') }}
     </h2>
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class=" md:w-5/12 margins ">
         <ConViewFields label="address">
           {{ contactInfo.orgAddress }}
         </ConViewFields>
       </div>
-      <div class="w-5/12 margins">
+      <div class=" md:w-5/12 margins ">
         <ConViewFields label="orgEmail">
           {{ contactInfo.orgEmail }}
         </ConViewFields>
       </div>
     </div>
+
     <h2 class="title">
       {{ $t('contact.engagements') }}
     </h2>
+
     <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
       <ConShowEngagaments
         v-for="(eng, index) in contactInfo.engagements"
@@ -67,14 +74,15 @@
         :number="eng.numParticipants"
       />
     </div>
-    <div class="flex justify-start mb-4">
-      <div class="w-3/12 margins">
+
+    <div class="md:flex flex-wrap justify-start mb-4">
+      <div class="md:w-4/12 margins">
         <AppButton custom_style="btn-cancel" type="button" data_cypress="contactDetailBackButton" @click="goBack">
           {{ $t('contact.back') }}
         </AppButton>
       </div>
-      <div class="w-3/12 margins">
-        <AppButton custom_style="btn-extra" data_cypress="contactDetailEditButton" @click="goEdit">
+      <div class="md:w-4/12 margins">
+        <AppButton custom_style="btn-extra" type="button" data_cypress="contactDetailEditButton" @click="goEdit">
           {{ $t('contact.edit') }}
         </appbutton>
       </div>
@@ -151,8 +159,6 @@ export default {
 
 <style scoped>
 .contactForm {
-  margin: auto;
-  font-family: 'DejaVu Serif', 'Roboto slab', 'sans-serif', 'Helvetica Neue';
   @apply bg-white text-black;
 }
 .title {
@@ -162,15 +168,14 @@ export default {
   @apply px-1 py-2 m-2;
 }
 .btn-cancel {
-  @apply justify-start bg-gray-300 w-11/12 text-black h-12;
+  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12 font-display;
 }
 .btn-extra {
-  @apply w-11/12 h-12 justify-start;
+  @apply w-full mt-2 h-12 justify-start font-display;
 }
-.messageBox {
-  @apply text-center text-2xl align-bottom mb-4 h-12 min-h-0 mt-2 text-black bg-green-700;
-}
-.error {
-  @apply bg-red-700;
+@media screen and (max-width: 768px) {
+  h1 { font-size: 28px !important; }
+  h2 { font-size: 18px !important; }
+  h3 { font-size: 16px !important; }
 }
 </style>

--- a/pages/view/engagement/_id.vue
+++ b/pages/view/engagement/_id.vue
@@ -1,35 +1,35 @@
 <template>
-  <div class="engagementForm">
-    <h1 class="title">
+  <div class="engagementForm font-body mt-8 mx-2 ">
+    <h1 class="title pb-6">
       {{ $t('engagement.engagement') }}
     </h1>
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="subject">
           {{ engagement.subject }}
         </EngViewFields>
       </div>
-      <div class="w-5/12 margins">
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="type">
           {{ engagement.type }}
         </EngViewFields>
       </div>
     </div>
 
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="date">
           {{ engagement.date.substring(0, 10) }}
         </EngViewFields>
       </div>
-      <div class="w-5/12 margins">
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="participants">
           {{ engagement.numParticipants }}
         </EngViewFields>
       </div>
     </div>
-    <div class="flex mb-4">
-      <div class="w-5/12 margins">
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="tags">
           <ul>
             <li v-for="(tag, index) in engagement.tags" :key="index">
@@ -38,13 +38,13 @@
           </ul>
         </EngViewFields>
       </div>
-      <div class="w-5/12 margins">
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="policy">
           {{ engagement.policyProgram }}
         </EngViewFields>
       </div>
     </div>
-    <div class="flex mb-4">
+    <div class=" md:flex flex-wrap mb-4 ">
       <div class="margins break-all">
         <EngViewFields label="description">
           <br />
@@ -52,7 +52,7 @@
         </EngViewFields>
       </div>
     </div>
-    <div class="flex mb-4">
+    <div class=" md:flex flex-wrap mb-4 ">
       <div class="margins">
         <EngViewFields label="comments">
           <br />
@@ -84,13 +84,13 @@
       />
     </div>
 
-    <div class="flex justify-start mb-12">
-      <div class="w-1/4 margins">
+    <div class="md:flex flex-wrap justify-start mb-4">
+      <div class="md:w-4/12 margins">
         <AppButton class="font-display" btntype="button" custom_style="btn-cancel" data_cypress="formButton" @click="goBack">
           {{ $t('contact.back') }}
         </AppButton>
       </div>
-      <div class="w-1/4 margins">
+      <div class="md:w-4/12 margins">
         <AppButton class="font-display" btntype="button" custom_style="btn-extra" data_cypress="formButton">
           {{ $t('engagement.edit') }}
         </AppButton>
@@ -148,20 +148,23 @@ export default {
 
 <style scoped>
 .engagementForm {
-  margin: auto;
-  font-family: 'DejaVu Serif', 'Roboto slab', 'sans-serif', 'Helvetica Neue';
   @apply bg-white text-black;
 }
 .btn-cancel {
-  @apply justify-start bg-gray-300 w-11/12 text-black h-12;
+  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12;
 }
 .btn-extra {
-  @apply w-11/12 h-12 justify-start;
+  @apply w-full mt-2 h-12 justify-start;
 }
 .title {
   @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-4xl pt-4;
 }
 .margins {
   @apply px-1 py-2 m-2;
+}
+@media screen and (max-width: 768px) {
+  h1 { font-size: 28px !important; }
+  h2 { font-size: 18px !important; }
+  h3 { font-size: 16px !important; }
 }
 </style>


### PR DESCRIPTION
Updated mobile versins of the Add Contact, Edit Contact and buttons of the Add engagements 

#246[Bug] Mobile view Add engagement/contact 
https://taiga.dts-stn.com/project/pond-knowlege-management-portal/issue/246?kanban-status=99

CSS in div classes changes to have fields at full size when media screen is less than 768px

# Story Acceptance Criteria

## Test Instructions

1. Go to Add contact  or Edit contact or Add engagements (for buttons only)
1. Change the screen size using dev tools to anything less than 768px (ipad)

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
