### PR TITLE
Differentiated edit and detail view labels

### DIFF
--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -119,7 +119,7 @@
               class="orange block tracking-wide text-black text-md font-bold font-body mb-4"
               for="description"
             >
-              {{ $t('engagement.description') }}
+              {{ $t('engagement.editDescription') }}
             </label>
             <br />
             <textarea
@@ -181,7 +181,7 @@
               class="block tracking-wide text-black text-md font-bold font-body mb-4"
               for="comments"
             >
-              {{ $t('engagement.comments') }}
+              {{ $t('engagement.editComments') }}
             </label>
             <br />
             <textarea

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -135,12 +135,12 @@ export default {
     type: 'Engagement type',
     date: 'Date',
     participants: 'Number of participants',
-    description:
-      'Description (Maximum 1000 characters. Additional characters will not be saved.)',
+    description: 'Description',
+    editDescription: 'Description (Maximum 1000 characters. Additional characters will not be saved.)',
     policy: 'Policy / program',
     tags: 'Tags',
-    comments:
-      'Comments (Maximum 140 characters. Additional characters will not be saved.)',
+    comments: 'Comments',
+    editComments: 'Comments (Maximum 140 characters. Additional characters will not be saved.)',
     cancel: 'Cancel',
     save: 'Save',
     edit: 'Edit',

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -137,11 +137,12 @@ export default {
     date: 'Date',
     participants: 'Nombre de participants',
     description:
-      'Description (1000 caractères maximum. Les caractères supplémentaires ne seront pas enregistrés.)',
+      'Description',
+    editDescription: 'Description (1000 caractères maximum. Les caractères supplémentaires ne seront pas enregistrés.)',
     policy: 'Politique / programme',
     tags: 'Mots clés',
-    comments:
-      'Commentaires (140 caractères maximum. Les caractères supplémentaires ne seront pas enregistrés.)',
+    comments: 'Commentaires',
+    editComments: 'Commentaires (140 caractères maximum. Les caractères supplémentaires ne seront pas enregistrés.)',
     cancel: 'Annuler',
     save: 'Sauver',
     edit: 'Modifier',

--- a/pages/view/engagement/_id.vue
+++ b/pages/view/engagement/_id.vue
@@ -52,8 +52,8 @@
         </EngViewFields>
       </div>
     </div>
-    <div class=" md:flex flex-wrap mb-4 ">
-      <div class="margins">
+    <div class="md:flex flex-wrap mb-4 ">
+      <div class="margins w-4/5">
         <EngViewFields label="comments">
           <br />
           <EngComments


### PR DESCRIPTION
# Description

[#255 [BUG] Detail and Edit field labels need to be differentiated](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/issue/255)

This PR adds separate labels for detail view and form views for Engagements.

## Test Instructions

1. Navigate to an Engagement detail view
1. See that Comments and Description labels no longer contain validation messages
1. Navigate to the Engagement form
1. See that Comments and Description labels contain validation messages

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
