### PR TITLE
Differentiated edit and detail labels

### DIFF
--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -148,7 +148,7 @@
                 class="orange block tracking-wide text-black text-md font-bold font-body mb-4"
                 for="description"
               >
-                {{ $t('engagement.description') }}
+                {{ $t('engagement.editDescription') }}
               </label>
               <br />
               <textarea
@@ -231,7 +231,7 @@
                 class="block tracking-wide text-black text-md font-bold font-body mb-4"
                 for="comments"
               >
-                {{ $t('engagement.comments') }}
+                {{ $t('engagement.editComments') }}
               </label>
               <br />
               <textarea

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -137,13 +137,13 @@ export default {
     date: 'Date',
     participants: 'Number of participants',
     numParticipants: 'Participants',
-    description:
-      'Description (Maximum 1000 characters. Additional characters will not be saved.)',
+    description: 'Description',
+    editDescription: 'Description (Maximum 1000 characters. Additional characters will not be saved.)',
     policy: 'Policy / program',
     tags: 'Tags:',
     tagLabel: 'Start typing and press enter to add new tags',
-    comments:
-      'Comments (Maximum 140 characters. Additional characters will not be saved.)',
+    comments: 'Comments',
+    editComments: 'Comments (Maximum 140 characters. Additional characters will not be saved.)',
     cancel: 'Cancel',
     save: 'Save',
     edit: 'Edit',

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -144,8 +144,8 @@ export default {
     policy: 'Politique / programme',
     tags: 'Mots clés:',
     tagLabel: 'Commencez à taper et sélectionnez la balise existante ou appuyez sur Entrée pour ajouter de nouvelles balises',
-    comments:
-      'Commentaires (140 caractères maximum. Les caractères supplémentaires ne seront pas enregistrés.)',
+    comments: 'Commentaires',
+    editComments: 'Commentaires (140 caractères maximum. Les caractères supplémentaires ne seront pas enregistrés.)',
     cancel: 'Annuler',
     save: 'Sauver',
     edit: 'Modifier',


### PR DESCRIPTION
# Description

These changes were wiped out in the last conflict merge. Adding them again.

## Test Instructions

1. Navigate to an Engagement detail view
1. See that Comments and Description labels no longer contain validation messages
1. Navigate to the Engagement form
1. See that Comments and Description labels contain validation messages

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
