### PR TITLE
 updated header logo

### DIFF
--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -29,7 +29,7 @@
           <select
             v-model="contactInfo.type"
             class="formSelect"
-            @change="onStanding($event)"
+            @change="onType($event)"
           >
             <option value="Federal">
               {{ $t('contact.federal') }}
@@ -533,10 +533,10 @@
               class="formSelect"
               @change="onStanding($event)"
             >
-              <option value="false">
+              <option :value="false">
                 {{ $t('contact.no') }}
               </option>
-              <option value="true">
+              <option :value="true">
                 {{ $t('contact.yes') }}
               </option>
             </select>

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -29,7 +29,7 @@
           <select
             v-model="contactInfo.type"
             class="formSelect"
-            @change="onStanding($event)"
+            @change="onType($event)"
           >
             <option value="Federal">
               {{ $t('contact.federal') }}
@@ -533,10 +533,10 @@
               class="formSelect"
               @change="onStanding($event)"
             >
-              <option value="false">
+              <option :value="false">
                 {{ $t('contact.no') }}
               </option>
-              <option value="true">
+              <option :value="true">
                 {{ $t('contact.yes') }}
               </option>
             </select>

--- a/components/layout/AppHeader.vue
+++ b/components/layout/AppHeader.vue
@@ -1,7 +1,6 @@
 <template>
   <div>
-    <div ref="top" class="xl:flex xl:mx-16 sm:flex justify-between p-4">
-      <a name="nav-top-page" />
+    <div id="nav-top-page" ref="top" class="xl:flex xl:mx-16 sm:flex justify-between p-4">
       <div id="canadaImg" class="w-64 lg:w-1/4" data-cy="canada-link">
         <div v-if="this.$i18n.locale === 'en'">
           <a :alt="$t('header.linkAlt')" :href="$t('header.link')" target="_blank">


### PR DESCRIPTION
## updated Header and Bug on contact forms 

Currently the Canada log on the header is in the center of the page 
this fix the issue and removes the unnecessary a tag for the top of page 

###Task # 272

##Story Acceptance Criteria

n/a

## Test Instructions

1. Run the app logo should be on the top left side 
2 try to add a non-federal contact it should not fail with boolean cast error 


## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
