### PR TITLE
Clear fields on submit

### DIFF
--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -430,7 +430,6 @@ export default {
           this.engagementDetail = this.resetForm()
           this.reloadComponent()
           setTimeout(() => { this.$v.$reset() }, 0)
-          this.$scrollTo(this.$refs.top)
           this.attemptSubmit = false
         } catch (e) {
           this.notification('error', e.response.data.message)

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -310,6 +310,7 @@ export default {
         message: null,
         goBack: false
       },
+      /*
       engagementDetail: {
         subject: '',
         type: '',
@@ -321,6 +322,8 @@ export default {
         comments: '',
         tags: []
       },
+      */
+      engagementDetail: this.resetForm(),
       inputTag: '',
       engagementTypes: [
         { type: this.$t('engagementTypes.one') },
@@ -396,16 +399,25 @@ export default {
       this.message.type = ''
       this.message.message = null
       clearTimeout(this.timeout)
-      if (!this.message.goBack) {
-        this.message.goBack = false
-        this.goBack()
-      }
     },
     emptyContacts() {
       return (this.engagementDetail.contacts.length === 0)
     },
     goBack() {
       this.$router.back()
+    },
+    resetForm() {
+      return {
+        subject: '',
+        type: '',
+        date: new Date(),
+        description: '',
+        numParticipants: 0,
+        contacts: [],
+        policyProgram: '',
+        comments: '',
+        tags: []
+      }
     },
     async submitForm(engagementDetail) {
       this.$v.$touch()
@@ -420,6 +432,9 @@ export default {
             engagementDetail
           })
           this.notification('success', 'engagment created')
+          this.engagementDetail = this.resetForm()
+          setTimeout(() => { this.$v.$reset() }, 0)
+          this.attemptSubmit = false
         } catch (e) {
           this.notification('error', e.response.data.message)
         }

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -302,19 +302,6 @@ export default {
         message: null,
         goBack: false
       },
-      /*
-      engagementDetail: {
-        subject: '',
-        type: '',
-        date: new Date(),
-        description: '',
-        numParticipants: 0,
-        contacts: [],
-        policyProgram: '',
-        comments: '',
-        tags: []
-      },
-      */
       engagementDetail: this.resetForm(),
       inputTag: '',
       engagementTypes: [

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -18,6 +18,7 @@
         Contact
       </h2>
       <select-contact
+        :key="componentKey"
         @childToParent="onChildClick"
         @blur="$v.engagementDetail.contacts.$touch()"
       />
@@ -397,7 +398,7 @@ export default {
     goBack() {
       this.$router.back()
     },
-    forceRender() {
+    reloadComponent() {
       this.componentKey += 1
     },
     resetForm() {
@@ -427,6 +428,7 @@ export default {
           })
           this.notification('success', 'engagment created')
           this.engagementDetail = this.resetForm()
+          this.reloadComponent()
           setTimeout(() => { this.$v.$reset() }, 0)
           this.$scrollTo(this.$refs.top)
           this.attemptSubmit = false

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -295,6 +295,7 @@ export default {
       datetest: new Date().toISOString(),
       mySVG: require('../../assets/images/calendar.svg'),
       idFromChild: [],
+      componentKey: 0,
       message: {
         type: null,
         message: null,
@@ -395,6 +396,9 @@ export default {
     },
     goBack() {
       this.$router.back()
+    },
+    forceRender() {
+      this.componentKey += 1
     },
     resetForm() {
       return {

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div title="engagementForm" class="mx-12">
+  <div ref="top" title="engagementForm" class="mx-12">
     <div v-if="attemptSubmit && invalidFields.length" ref="messageBox" class="error-list mt-6">
       <h1 class="text-xl text-red-600">
         {{ $t('engagementValidation.messageTitle') }}
@@ -260,16 +260,6 @@
             {{ message.message }}
           </span>
         </div>
-        <div
-          v-if="message.message != null"
-          class="messageBox"
-          :class="[message.type == 'error' ? ' error' : ' ']"
-        >
-          <span>
-            {{ message.message }}
-          </span>
-        </div>
-
         <div class="md:flex flex-wrap justify-start mb-12">
           <div class=" md:w-4/12 margins">
             <AppButton class="font-display" custom_style="btn-cancel" btntype="button" data_cypress="formButton" @click="goBack">
@@ -434,6 +424,7 @@ export default {
           this.notification('success', 'engagment created')
           this.engagementDetail = this.resetForm()
           setTimeout(() => { this.$v.$reset() }, 0)
+          this.$scrollTo(this.$refs.top)
           this.attemptSubmit = false
         } catch (e) {
           this.notification('error', e.response.data.message)


### PR DESCRIPTION
# Description

Clear input fields after submit the form (Basically took Marco's code for the contact form). 
Bug fixed: 'engagement created' message display twice after submitting the form

## Test Instructions

- Go to the engagement form
- Fill in required fields
- Click on the save button
- Input fields should be cleared

## Help Requested

Took Marco's implementation for the contact form #126 

## Reviewers

@will0684 @MarcoGoC @nghe0001 @bcloutier7 @andr0272 @shewood  

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
