### PR TITLE
 View Contact, engagement, tags update

### DIFF
--- a/components/contact/ConShowEngagements.vue
+++ b/components/contact/ConShowEngagements.vue
@@ -8,10 +8,15 @@
           </span>
           {{ type }}, {{ date }}
         </div>
-        <div>
-          <span v-for="(tag) in tags" :key="tag.id" class="tag">
+        <div class=" md:auto flex ">
+          <ul class="md:inline-flex md:mt-0 display-block">
+            <li v-for="(tag) in tags" :key="tag.id" class="tag">
+              {{ tag }}
+            </li>
+          </ul>
+          <!-- <span v-for="(tag) in tags" :key="tag.id" class="tag">
             {{ tag }}
-          </span>
+          </span> -->
         </div>
       </div>
 
@@ -84,9 +89,9 @@ export default {
     },
 
     max3Contacts(inputArray) {
-      if (inputArray.length > 3) {
+      if (inputArray.length > 1) {
         this.moreContacts = true
-        return inputArray.slice(0, 3)
+        return inputArray.slice(0, 1)
       } else {
         this.moreContacts = false
         return inputArray
@@ -121,6 +126,6 @@ export default {
   width: 56px;
 }
 .tag {
-  @apply bg-rmp-lt-blue text-rmp-md-blue rounded-full px-4 py-1 ml-2;
+  @apply bg-rmp-lt-blue text-rmp-md-blue rounded-full px-4 py-0 leading-8 ml-2 mt-2;
 }
 </style>

--- a/components/contact/ConShowEngagements.vue
+++ b/components/contact/ConShowEngagements.vue
@@ -8,15 +8,12 @@
           </span>
           {{ type }}, {{ date }}
         </div>
-        <div class=" md:auto flex ">
-          <ul class="md:inline-flex md:mt-0 display-block">
+        <div class=" md:w-auto flex ">
+          <ul class="xl:inline-flex md:mt-0 display-block">
             <li v-for="(tag) in tags" :key="tag.id" class="tag">
               {{ tag }}
             </li>
           </ul>
-          <!-- <span v-for="(tag) in tags" :key="tag.id" class="tag">
-            {{ tag }}
-          </span> -->
         </div>
       </div>
 
@@ -39,12 +36,7 @@
         </div>
       </div>
 
-      <div class="col-start-6 col-span-12 sm:col-span-2 md:col-span-1 flex items-center">
-        <!-- <button
-          class="btn-round"
-          data_cypress="link"
-          @click="modalDisplay(id)"
-        /> -->
+      <div class="min-width col-start-6 col-span-12 sm:col-span-2 md:col-span-1 flex items-center">
         <button
           class="btn-round"
           data_cypress="link"
@@ -127,5 +119,8 @@ export default {
 }
 .tag {
   @apply bg-rmp-lt-blue text-rmp-md-blue rounded-full px-4 py-0 leading-8 ml-2 mt-2;
+}
+.min-width {
+  min-width: 60px;
 }
 </style>

--- a/components/contact/ConViewFields.vue
+++ b/components/contact/ConViewFields.vue
@@ -23,7 +23,7 @@ export default {
 
 <style scoped>
 .Label {
-  @apply font-semibold text-rmp-orange text-xl;
+  @apply font-semibold text-rmp-orange text-base;
 }
 @media screen and (max-width: 768px) {
   .Label { font-size: 16px !important; }

--- a/components/engagement/EngViewFields.vue
+++ b/components/engagement/EngViewFields.vue
@@ -3,7 +3,7 @@
     <p class="Label">
       {{ $t('engagement.' + label) }}
       :&nbsp;
-      <span class="text-black">
+      <span class="text-black font-medium">
         <slot>
           default text
         </slot>
@@ -23,7 +23,7 @@ export default {
 
 <style scoped>
 .Label {
-  @apply font-bold text-rmp-orange text-xl;
+  @apply font-semibold text-rmp-orange text-base;
 }
 @media screen and (max-width: 768px) {
   .Label { font-size: 16px !important; }

--- a/pages/view/contact/_id.vue
+++ b/pages/view/contact/_id.vue
@@ -5,7 +5,7 @@
     </h1>
 
     <div class=" md:flex flex-wrap mb-4 ">
-      <div class="md:w-5/12 margins">
+      <div class="md:w-auto margins">
         <ConViewFields label="type">
           {{ $t('contact.' + contactInfo.type) }}
         </ConViewFields>
@@ -67,12 +67,16 @@
     <div class=" md:flex flex-wrap mb-4 ">
       <div class="md:w-5/12 margins">
         <ConViewFields label="keyContactEmail">
-          {{ contactInfo.keyContactEmail }}
+          <a :href="'mailto:'+ contactInfo.keyContactEmail">
+            {{ contactInfo.keyContactEmail }}
+          </a>
         </ConViewFields>
       </div>
       <div class="md:w-5/12 margins">
         <ConViewFields label="phone">
-          {{ contactInfo.keyContactPhone }}
+          <a :href="'tel:' + contactInfo.keyContactPhone">
+            {{ contactInfo.keyContactPhone }}
+          </a>
         </ConViewFields>
       </div>
     </div>
@@ -138,12 +142,16 @@
     <div class=" md:flex flex-wrap mb-4 ">
       <div class="md:w-5/12 margins">
         <ConViewFields label="orgEmail">
-          {{ contactInfo.orgEmail }}
+          <a :href="'mailto:'+ contactInfo.orgEmail">
+            {{ contactInfo.orgEmail }}
+          </a>
         </ConViewFields>
       </div>
       <div class="md:w-5/12 margins">
         <ConViewFields label="phone">
-          {{ contactInfo.orgPhone }}
+          <a :href="'mailto:'+ contactInfo.orgPhone">
+            {{ contactInfo.orgPhone }}
+          </a>
         </ConViewFields>
       </div>
     </div>
@@ -245,6 +253,7 @@
     </div>
   </div>
 </template>
+
 <script>
 import { mapState } from 'vuex'
 
@@ -315,19 +324,19 @@ export default {
 
 <style scoped>
 .contactForm {
-  @apply bg-white text-black;
+  @apply bg-white text-black text-base;
 }
 .title {
-  @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-4xl pt-4;
+  @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-2xl pt-4;
 }
 .margins {
   @apply px-1 py-2 m-2;
 }
 .btn-cancel {
-  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12 font-display;
+  @apply justify-start bg-gray-300 w-full mt-2 text-black h-12;
 }
 .btn-extra {
-  @apply w-full mt-2 h-12 justify-start font-display;
+  @apply w-full mt-2 h-12 justify-start;
 }
 @media screen and (max-width: 768px) {
   h1 { font-size: 28px !important; }

--- a/pages/view/engagement/_id.vue
+++ b/pages/view/engagement/_id.vue
@@ -1,41 +1,34 @@
 <template>
-  <div class="engagementForm font-body mt-8 mx-2 ">
+  <div class="engagementForm font-body mt-8 mx-4 xl:mx-16">
     <h1 class="title pb-6">
       {{ $t('engagement.engagement') }}
     </h1>
+
     <div class=" md:flex flex-wrap mb-4 ">
-      <div class=" md:w-5/12 margins ">
+      <div class=" md:w-auto margins ">
         <EngViewFields label="subject">
           {{ engagement.subject }}
-        </EngViewFields>
-      </div>
-      <div class=" md:w-5/12 margins ">
-        <EngViewFields label="type">
-          {{ engagement.type }}
         </EngViewFields>
       </div>
     </div>
 
     <div class=" md:flex flex-wrap mb-4 ">
       <div class=" md:w-5/12 margins ">
+        <EngViewFields label="type">
+          {{ engagement.type }}
+        </EngViewFields>
+      </div>
+      <div class=" md:w-5/12 margins ">
         <EngViewFields label="date">
           {{ engagement.date.substring(0, 10) }}
         </EngViewFields>
       </div>
+    </div>
+
+    <div class=" md:flex flex-wrap mb-4 ">
       <div class=" md:w-5/12 margins ">
         <EngViewFields label="participants">
           {{ engagement.numParticipants }}
-        </EngViewFields>
-      </div>
-    </div>
-    <div class=" md:flex flex-wrap mb-4 ">
-      <div class=" md:w-5/12 flex margins ">
-        <EngViewFields label="tags">
-          <ul class="flex">
-            <li v-for="(tag, index) in engagement.tags" :key="index" class="tags">
-              {{ tag }}
-            </li>
-          </ul>
         </EngViewFields>
       </div>
       <div class=" md:w-5/12 margins ">
@@ -44,6 +37,19 @@
         </EngViewFields>
       </div>
     </div>
+
+    <div class=" md:flex flex-wrap mb-4 ">
+      <div class="  margins ">
+        <EngViewFields label="tags">
+          <ul class="md:inline-flex md:mt-0 display-block">
+            <li v-for="(tag, index) in engagement.tags" :key="index" class="tags">
+              {{ tag }}
+            </li>
+          </ul>
+        </EngViewFields>
+      </div>
+    </div>
+
     <div class=" md:flex flex-wrap mb-4 ">
       <div class="margins break-all">
         <EngViewFields label="description">
@@ -52,8 +58,9 @@
         </EngViewFields>
       </div>
     </div>
+
     <div class="md:flex flex-wrap mb-4 ">
-      <div class="margins w-4/5">
+      <div class="margins w-full">
         <EngViewFields label="comments">
           <br />
           <EngComments
@@ -67,6 +74,7 @@
     <h2 class="title">
       {{ $t('engagement.contacts') }}
     </h2>
+
     <div class="max-w-full px-4 my-8 py-6 border border-gray-500">
       <EngShowContacts
         v-for="(con, index) in engagement.contacts"
@@ -148,7 +156,7 @@ export default {
 
 <style scoped>
 .engagementForm {
-  @apply bg-white text-black;
+  @apply bg-white text-black text-base;
 }
 .btn-cancel {
   @apply justify-start bg-gray-300 w-full mt-2 text-black h-12;
@@ -157,13 +165,13 @@ export default {
   @apply w-full mt-2 h-12 justify-start;
 }
 .title {
-  @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-4xl pt-4;
+  @apply text-rmp-md-blue text-left tracking-wide font-extrabold text-2xl pt-4;
 }
 .margins {
   @apply px-1 py-2 m-2;
 }
 .tags {
-  @apply flex font-thin text-base bg-rmp-lt-blue text-rmp-md-blue rounded-full px-4 py-1 ml-2 items-center mt-4;
+  @apply  bg-rmp-lt-blue text-rmp-md-blue rounded-full px-4 py-1 ml-2 mt-2;
 }
 @media screen and (max-width: 768px) {
   h1 { font-size: 28px !important; }

--- a/pages/view/engagement/_id.vue
+++ b/pages/view/engagement/_id.vue
@@ -39,7 +39,7 @@
     </div>
 
     <div class=" md:flex flex-wrap mb-4 ">
-      <div class="  margins ">
+      <div class=" md:auto flex margins ">
         <EngViewFields label="tags">
           <ul class="md:inline-flex md:mt-0 display-block">
             <li v-for="(tag, index) in engagement.tags" :key="index" class="tags">


### PR DESCRIPTION
## Description

Task #268 View details not in bold fonts. Contact & Engagements updated to have similar styling Tags were modified as well to match viewCard and View engagements in mobile version

## Test Instructions

1. Go to search select an engagement to view
1. on another tab go to search and select a contact to view 
1. compare the styling of both pages at full and mobile versions 

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
