### PR TITLE
extra comma on contact

### DIFF
--- a/components/engagement/EngShowContacts.vue
+++ b/components/engagement/EngShowContacts.vue
@@ -9,7 +9,7 @@
         <div>
           <span class="orangeText pr-0">{{ name }}</span>, <span v-if="orgname">{{ orgname }},</span> {{ title }}
         </div>
-        <div><a :href="'tel:' + phone">{{ phone }}</a>, <a :href="'mailto:'+ email">{{ email }}</a></div>
+        <div class="text-rmp-md-blue"><span v-if="phone" class="underline"><a :href="'tel:' + phone">{{ phone }}</a>,</span> <a :href="'mailto:'+ email" class="underline">{{ email }}</a></div>
       </div>
 
       <div class="col-span-12 sm:col-span-10 md:col-span-5">

--- a/components/engagement/EngShowContacts.vue
+++ b/components/engagement/EngShowContacts.vue
@@ -7,7 +7,7 @@
     >
       <div class="col-span-12 sm:col-span-10 md:col-span-6">
         <div>
-          <span class="orangeText pr-0">{{ name }}</span>, {{ orgname }}, {{ title }}
+          <span class="orangeText pr-0">{{ name }}</span>, <span v-if="orgname">{{ orgname }},</span> {{ title }}
         </div>
         <div><a :href="'tel:' + phone">{{ phone }}</a>, <a :href="'mailto:'+ email">{{ email }}</a></div>
       </div>


### PR DESCRIPTION
# Description

Bug fixed: extra comma and white space after contact name if organization name or phone number doesn't exist.
Add color and underline on the clickable phone number and email

## Test Instructions

- go to search contact page
- checkout the contact cards 
- on the left side of the contact, for the one that doesn't have organization name, only contact name and title are displayed. 

## Reviewers

@will0684 @MarcoGoC @shewood @nghe0001 @bcloutier7 @andr0272 

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
