### PR TITLE
280 - Contact Type drop down fix

### DIFF
--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -32,16 +32,16 @@
             @change="onType($event)"
           >
             <option value="Federal">
-              {{ $t('contact.federal') }}
+              {{ $t('contact.Federal') }}
             </option>
             <option value="External">
-              {{ $t('contact.external') }}
+              {{ $t('contact.External') }}
             </option>
             <option value="Provincial">
-              {{ $t('contact.provincial') }}
+              {{ $t('contact.Provincial') }}
             </option>
             <option value="International">
-              {{ $t('contact.international') }}
+              {{ $t('contact.International') }}
             </option>
           </select>
         </div>


### PR DESCRIPTION
## Description

280 - bug - Contact Type dropdown in Contact Form is not getting translated strings 
Updated options names to have the same name as the language file

## Test Instructions

1. Go to add contact 
1. Contact Type must have the correct names as opposed to a string 'contact.federal' etc. 

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
