### PR TITLE
226 notification

### DIFF
--- a/components/app/AppNotification.vue
+++ b/components/app/AppNotification.vue
@@ -1,18 +1,15 @@
 <template>
-  <div v-if="message.message != null" class="messageBox" :class="messageType">
+  <div v-if="notification.length" class="messageBox">
     <span>
-      {{ message.message }}
+      {{ notification }}
     </span>
   </div>
 </template>
 
 <script>
+import { mapState } from 'vuex'
 export default {
   name: 'AppMessageBox',
-
-  props: {
-    message: { type: Object, required: true }
-  },
 
   data() {
     return {
@@ -20,27 +17,17 @@ export default {
     }
   },
 
-  computed: {
-    messageType() {
-      return ` ${this.message.type}`
-    }
-  },
-
-  mounted() {
-    this.timeout = setTimeout(() => (this.message = ''), 5000)
-  },
-
-  beforeDestroy() {
-    clearTimeout(this.timeout)
+  computed: mapState({ notification: state => state.notifications.notification }),
+  created() {
+    this.timeout = setTimeout(() =>
+      (this.$store.dispatch('notifications/removeNotification')), 10000)
   }
 }
 </script>
 
 <style scoped>
 .messageBox {
-  @apply text-center text-2xl align-bottom mb-4 h-12 min-h-0 mt-2 text-black bg-green-700;
-}
-.error {
-  @apply bg-red-700;
+ font-size: 18px !important;
+  @apply bg-green-100 border border-green-400 px-4 rounded text-center font-medium mb-4 h-16 pt-3 min-h-0 mt-2 text-green-800;
 }
 </style>

--- a/components/app/AppNotification.vue
+++ b/components/app/AppNotification.vue
@@ -11,17 +11,7 @@ import { mapState } from 'vuex'
 export default {
   name: 'AppMessageBox',
 
-  data() {
-    return {
-      timeout: null
-    }
-  },
-
-  computed: mapState({ notification: state => state.notifications.notification }),
-  created() {
-    this.timeout = setTimeout(() =>
-      (this.$store.dispatch('notifications/removeNotification')), 10000)
-  }
+  computed: mapState({ notification: state => state.notifications.notification })
 }
 </script>
 

--- a/components/app/AppNotification.vue
+++ b/components/app/AppNotification.vue
@@ -1,23 +1,27 @@
 <template>
-  <div v-if="notification.length" class="messageBox">
-    <span>
-      {{ notification }}
-    </span>
+  <div
+    v-if="notification.length"
+    class="positionBox"
+  >
+    <div class="messageBox w-3/4 h-3/4">
+      <div class="mt-8 p-2">
+        {{ notification }}
+      </div>
+    </div>
   </div>
 </template>
-
 <script>
 import { mapState } from 'vuex'
 export default {
   name: 'AppMessageBox',
-
   computed: mapState({ notification: state => state.notifications.notification })
 }
 </script>
-
 <style scoped>
+.positionBox{
+  @apply fixed mx-auto h-6 inset-0 flex items-center justify-center;
+}
 .messageBox {
- font-size: 18px !important;
-  @apply bg-green-100 border border-green-400 px-4 rounded text-center font-medium mb-4 h-16 pt-3 min-h-0 mt-2 text-green-800;
+ @apply relative bg-green-100 border border-green-400 rounded text-center font-medium text-green-800;
 }
 </style>

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -685,11 +685,12 @@ export default {
           await this.$axios.post('/api/contact/addContact', {
             contactInfo
           })
-          this.notification('success', 'contact created')
-
+          this.$store.dispatch('notifications/addNotification', this.$t('notifications.ContactCreated'))
+          // TODO: This
+          // this.$scrollTo()
           this.contactInfo = this.resetForm()
+          // TODO: wrap this in nextTick instead of setTimeout()
           setTimeout(() => { this.$v.$reset() }, 0)
-
           this.didAttemptSubmit = false
         } catch (e) {
           this.notification('error', e.response.data.message)

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -739,7 +739,7 @@ export default {
             .post(`/api/contact/update?id=${this.$route.params.id}`, {
               contactInfo
             })
-            .then(this.$store.dispatch('notifications/addNotification', 'contact updated'))
+            .then(this.$store.dispatch('notifications/addNotification', this.$t('notifications.ContactUpdated')))
             .then(this.goBack())
         } catch (e) {
           this.notification('error', e.response.data.message)

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -739,7 +739,8 @@ export default {
             .post(`/api/contact/update?id=${this.$route.params.id}`, {
               contactInfo
             })
-            .then(this.notification('success', 'contact updated'))
+            .then(this.$store.dispatch('notifications/addNotification', 'contact updated'))
+            .then(this.goBack())
         } catch (e) {
           this.notification('error', e.response.data.message)
         }

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -413,10 +413,10 @@ export default {
           await this.$axios.post('/api/engagement/addEngagement', {
             engagementDetail
           })
-          this.notification('success', 'engagment created')
+          this.$store.dispatch('notifications/addNotification', this.$t('notifications.ContactUpdated'))
+          this.goBack()
           this.engagementDetail = this.resetForm()
           this.reloadComponent()
-          setTimeout(() => { this.$v.$reset() }, 0)
           this.attemptSubmit = false
         } catch (e) {
           this.notification('error', e.response.data.message)

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -210,5 +210,11 @@ export default {
     BMO: 'BMO',
     OntarioGov: 'Ontario Gov',
     OttawaMission: 'Ottawa Mission'
+  },
+  notifications: {
+    ContactCreated: 'Contact Created',
+    ContactUpdated: 'Contact Updated',
+    EngagementCreated: 'Engagement Created',
+    EngagementUpdated: 'EngagementUpdated'
   }
 }

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -213,5 +213,11 @@ export default {
     BMO: 'FR-BMO',
     OntarioGov: 'FR-Ontario Gov',
     OttawaMission: 'FR-Ottawa Mission'
+  },
+  notifications: {
+    ContactCreated: 'FR-Contact Created',
+    ContactUpdated: 'FR-Contact Updated',
+    EngagementCreated: 'FR-Engagement Created',
+    EngagementUpdated: 'FR-EngagementUpdated'
   }
 }

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -3,6 +3,7 @@
     <header>
       <AppHeader />
       <AppNavBtn v-if="shouldDisplayNav" />
+      <app-notification />
     </header>
     <main>
       <nuxt />
@@ -14,7 +15,11 @@
   </div>
 </template>
 <script>
+import AppNotification from '@/components/app/AppNotification.vue'
 export default {
+  components: {
+    'app-notification': AppNotification
+  },
   computed: {
     shouldDisplayNav() {
       return !(this.$route.path.includes('view') || this.$route.path.includes('edit') || this.$route.path.includes('dashboard'))

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -1,0 +1,21 @@
+export const state = () => ({
+  notification: []
+})
+
+export const mutations = {
+  SET_NOTIFICATION(state, notification) {
+    state.notification = notification
+  },
+  DELETE_NOTIFICATION(state) {
+    state.notification = []
+  }
+}
+
+export const actions = {
+  addNotification({ commit }, message) {
+    commit('SET_NOTIFICATION', message)
+  },
+  removeNotification({ commit }) {
+    commit('DELETE_NOTIFICATION')
+  }
+}

--- a/store/notifications.js
+++ b/store/notifications.js
@@ -12,8 +12,9 @@ export const mutations = {
 }
 
 export const actions = {
-  addNotification({ commit }, message) {
+  addNotification({ commit, dispatch }, message) {
     commit('SET_NOTIFICATION', message)
+    setTimeout(() => dispatch('removeNotification'), 5000)
   },
   removeNotification({ commit }) {
     commit('DELETE_NOTIFICATION')


### PR DESCRIPTION
# Description

[226 Display success notification on details page](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/226?kanban-status=74)

Updated notification framework to use vuex. Works across pages without delaying navigation. **(Only for success messages)**

# Story Acceptance Criteria

From: [115 View Engagement: Edit Mode](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/us/115?milestone=20)
User updates Engagement fields with valid user input and clicks submit, Engagement form is hidden and Engagement detail page is displayed with updated info and success prompt is displayed(toast message top of page? match strategy with Contact detail view)

## Test Instructions

1. Feature needs to be tested in 3 locations: Add contact page, Edit contact page, Add engagement page.
1. Follow the flow of each page (For Add contact, add a new contact etc...)
1. Check that a green prompt appears at the top of the site, displaying an appropriate message related to the task you completed
1. Check that the prompt disappears after 5 seconds. 

## Help Requested

- Update future pages using this same framework to save time
- Suggest (or PR) a solution for dynamic success/error notifications using this framework

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
