### PR TITLE
287 buttons size / 288 Error message box on mobile

### DIFF
--- a/components/app/AppButton.vue
+++ b/components/app/AppButton.vue
@@ -26,6 +26,8 @@ export default {
 
 <style scoped>
 .appButton {
+  min-width: 270px;
+  max-width: 300px;
   @apply bg-rmp-orange shadow text-white font-bold mt-12 py-2 px-6 rounded;
 }
 .appButton:hover {

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="contactForm font-body mt-8 mx-2 xl:mx-16">
     <div>
-      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list md:w-full">
+      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list w-full md:w-1/2">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">
           {{ $t('contactValidation.errorListTitle') }}
         </h2>
@@ -791,7 +791,6 @@ export default {
 }
 
 .error-list {
-  width: 50%;
   background-color: rgba(255, 0, 0, 0.1);
   @apply border border-red-500;
 }

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="contactForm font-body mt-8 mx-2">
+  <div class="contactForm font-body mt-8 mx-2 xl:mx-16">
     <div>
       <div v-if="didAttemptSubmit && invalidFields.length" class="error-list md:w-full">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">
@@ -554,12 +554,12 @@
         </div>
 
         <div class="md:flex flex-wrap justify-start mb-4">
-          <div class=" md:w-4/12 margins">
+          <div class="  margins">
             <AppButton custom_style="btn-cancel" data_cypress="cancelButton" type="button" @click="goBack">
               {{ $t('contact.cancel') }}
             </AppButton>
           </div>
-          <div class=" md:w-4/12 margins">
+          <div class="  margins">
             <AppButton custom_style="btn-extra" data_cypress="submitButton">
               {{ $t('contact.save') }}
             </AppButton>

--- a/components/contact/ContactForm.vue
+++ b/components/contact/ContactForm.vue
@@ -1,9 +1,5 @@
 <template>
-<<<<<<< HEAD
   <div class="contactForm font-body mt-8 mx-2 xl:mx-16">
-=======
-  <div class="contactForm font-body mt-8 mx-12">
->>>>>>> main
     <div>
       <div v-if="didAttemptSubmit && invalidFields.length" class="error-list w-full md:w-1/2">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="contactForm font-body mt-8 mx-2 xl:mx-16">
     <div>
-      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list md:w-full">
+      <div v-if="didAttemptSubmit && invalidFields.length" class="error-list w-full md:w-1/2">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">
           {{ $t('contactValidation.errorListTitle') }}
         </h2>
@@ -803,7 +803,6 @@ export default {
 }
 
 .error-list {
-  width: 50%;
   background-color: rgba(255, 0, 0, 0.1);
   @apply border border-red-500;
 }

--- a/components/contact/ContactForm2.vue
+++ b/components/contact/ContactForm2.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="contactForm font-body mt-8 mx-12">
+  <div class="contactForm font-body mt-8 mx-2 xl:mx-16">
     <div>
       <div v-if="didAttemptSubmit && invalidFields.length" class="error-list md:w-full">
         <h2 ref="displayErrors" class="text-xl ml-2 text-red-600">
@@ -554,12 +554,12 @@
         </div>
 
         <div class=" md:flex flex-wrap justify-start mb-4">
-          <div class=" md:w-4/12 margins">
+          <div class=" margins">
             <AppButton custom_style="btn-cancel" data_cypress="cancelButton" type="button" @click="goBack">
               {{ $t('contact.cancel') }}
             </AppButton>
           </div>
-          <div class=" md:w-4/12 margins">
+          <div class=" margins">
             <AppButton custom_style="btn-extra" data_cypress="submitButton">
               {{ $t('contact.save') }}
             </AppButton>

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -501,7 +501,6 @@ export default {
   @apply appearance-none border border-red-500 rounded w-full
 }
 .error-list {
-  width: 50%;
   background-color: rgba(255,0,0,0.1);
   @apply border border-red-500;
 }

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="top" title="engagementForm" class="mx-12">
+  <div ref="top" title="engagementForm" class="mx-2 xl:mx-16">
     <div v-if="attemptSubmit && invalidFields.length" ref="messageBox" class="error-list mt-6">
       <h1 class="text-xl text-red-600">
         {{ $t('engagementValidation.messageTitle') }}
@@ -262,12 +262,12 @@
           </span>
         </div>
         <div class="md:flex flex-wrap justify-start mb-12">
-          <div class=" md:w-4/12 margins">
+          <div class="  margins">
             <AppButton class="font-display" custom_style="btn-cancel" btntype="button" data_cypress="formButton" @click="goBack">
               {{ $t('engagement.cancel') }}
             </AppButton>
           </div>
-          <div class=" md:w-4/12 margins">
+          <div class="  margins">
             <AppButton class="font-display" custom_style="btn-extra" data_cypress="formButton">
               {{ $t('engagement.save') }}
             </AppButton>
@@ -490,6 +490,9 @@ export default {
 }
 .delete-btn {
   @apply text-rmp-dk-blue bg-white rounded-full items-center justify-center pl-2 pr-2 ml-2
+}
+.margins {
+  @apply py-2 mx-2 my-1;
 }
 .error {
   @apply text-red-500 text-xs italic;

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="top" title="engagementForm" class="mx-2 xl:mx-16">
-    <div v-if="attemptSubmit && invalidFields.length" ref="messageBox" class="error-list mt-6">
+    <div v-if="attemptSubmit && invalidFields.length" ref="messageBox" class="error-list w-full md:w-1/2 mt-6">
       <h1 class="text-xl text-red-600">
         {{ $t('engagementValidation.messageTitle') }}
       </h1>

--- a/pages/view/contact/_id.vue
+++ b/pages/view/contact/_id.vue
@@ -240,12 +240,12 @@
     </div>
 
     <div class="md:flex flex-wrap justify-start mb-4">
-      <div class="md:w-4/12 margins">
+      <div class=" margins">
         <AppButton custom_style="btn-cancel" type="button" data_cypress="contactDetailBackButton" @click="goBack">
           {{ $t('contact.back') }}
         </AppButton>
       </div>
-      <div class="md:w-4/12 margins">
+      <div class=" margins">
         <AppButton custom_style="btn-extra" type="button" data_cypress="contactDetailEditButton" @click="goEdit">
           {{ $t('contact.edit') }}
         </appbutton>

--- a/pages/view/engagement/_id.vue
+++ b/pages/view/engagement/_id.vue
@@ -93,12 +93,12 @@
     </div>
 
     <div class="md:flex flex-wrap justify-start mb-4">
-      <div class="md:w-4/12 margins">
+      <div class=" margins">
         <AppButton class="font-display" btntype="button" custom_style="btn-cancel" data_cypress="formButton" @click="goBack">
           {{ $t('contact.back') }}
         </AppButton>
       </div>
-      <div class="md:w-4/12 margins">
+      <div class=" margins">
         <AppButton class="font-display" btntype="button" custom_style="btn-extra" data_cypress="formButton">
           {{ $t('engagement.edit') }}
         </AppButton>


### PR DESCRIPTION
# Description

[287] https://taiga.dts-stn.com/project/pond-knowlege-management-portal/issue/287?kanban-status=101
[288] https://taiga.dts-stn.com/project/pond-knowlege-management-portal/issue/288?kanban-status=99

**Task 287**  
Buttons size across Add, View, and Edit (except engagement) were modified to have a common look and feel (size)
   on mobile (iPhone 5S min size) and full view.
Padding on form were updated to have a consistent size as well 

**Task 288**
Error message box on mobile was changed to have full width when on mobile and 50% when min-width = 768px (iPad)

## Test Instructions

1. Go to Add (contact, and Engagement) scroll to the bottom of the page, 
     using devTools to change to different mobile versions, inspect the size of the buttons
     press enter to submit the form making sure required fields are not entered inspect the size of the error box.
1. Repeat step 1 for Edit (contact)
1. Repeat step 1 for view contact and engagement (except for the error box)

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
