### PR TITLE
Added descending sort on dates during Engagements query

### DIFF
--- a/api/routes/engagement.js
+++ b/api/routes/engagement.js
@@ -11,7 +11,7 @@ const router = Router()
 
 router.get('/engagements', async(req, res) => {
   try {
-    const engagements = await Engagement.find().populate('contacts')
+    const engagements = await Engagement.find().sort({ date: -1 }).populate('contacts')
 
     if (!engagements) {
       consola.error('No engagements exist')


### PR DESCRIPTION
# Description

/engagement/engagements endpoint now returns all Engagements in descending order by date (most recent first).

## Test Instructions

1. npm run dev on this branch
1. go to Engagements search and see Engagements are sorted by date descending
