### PR TITLE
289 contact list clipped on mobile / 291 tags styling on mobile

### DIFF
--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -217,12 +217,14 @@
             </p>
           </div>
           <div v-if="showTag" class="flex mt-6 ml-2">
-            <eng-tags v-for="(tag, index) in engagementDetail.tags" :key="index">
-              {{ tag }}
-              <button class="delete-btn" @click.prevent="deleteTag(index)">
-                x
-              </button>
-            </eng-tags>
+            <div class="flex-no-wrap md:flex">
+              <eng-tags v-for="(tag, index) in engagementDetail.tags" :key="index">
+                {{ tag }}
+                <button class="delete-btn" @click.prevent="deleteTag(index)">
+                  x
+                </button>
+              </eng-tags>
+            </div>
           </div>
         </div>
 
@@ -420,10 +422,14 @@ export default {
           await this.$axios.post('/api/engagement/addEngagement', {
             engagementDetail
           })
+
           this.$store.dispatch('notifications/addNotification', this.$t('notifications.ContactUpdated'))
-          this.goBack()
+
           this.engagementDetail = this.resetForm()
           this.reloadComponent()
+
+          // next two lines avoid having a clean form with errors on it
+          setTimeout(() => { this.$v.$reset() }, 0)
           this.attemptSubmit = false
         } catch (e) {
           this.notification('error', e.response.data.message)

--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -423,7 +423,7 @@ export default {
             engagementDetail
           })
 
-          this.$store.dispatch('notifications/addNotification', this.$t('notifications.ContactUpdated'))
+          this.$store.dispatch('notifications/addNotification', this.$t('notifications.EngagementCreated'))
 
           this.engagementDetail = this.resetForm()
           this.reloadComponent()

--- a/components/engagement/EngSelectedContact.vue
+++ b/components/engagement/EngSelectedContact.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- eslint-disable vue/singleline-html-element-content-newline -->
   <div>
-    <div class="flex max-w-full leading-10 bdr bottom top pt-6 pb-6 first">
+    <div class="flex max-w-full leading-10 bdr bottom pt-6 pb-6" :class="[arrayIndex == 0 ? 'first' : '']">
       <div class="pl-2 w-full lg:w-6/12">
         <div>
           <span class="orangeText pr-0">{{ name }}</span>, {{ orgname }}

--- a/components/engagement/EngSelectedContact.vue
+++ b/components/engagement/EngSelectedContact.vue
@@ -84,9 +84,4 @@ button.btn-round {
   width: 56px;
   min-width: 58px !important;
 }
-@media (max-width: 767px) {
-  .leftBorder {
-    @apply hidden;
-  }
-}
 </style>

--- a/components/engagement/EngSelectedContact.vue
+++ b/components/engagement/EngSelectedContact.vue
@@ -2,7 +2,7 @@
   <!-- eslint-disable vue/singleline-html-element-content-newline -->
   <div>
     <div class="flex max-w-full leading-10 bdr bottom top pt-6 pb-6 first">
-      <div class="w-6/12 pl-2">
+      <div class="pl-2 w-full lg:w-6/12">
         <div>
           <span class="orangeText pr-0">{{ name }}</span>, {{ orgname }}
         </div>
@@ -18,7 +18,7 @@
         <div>{{ date }}, {{ number }} {{ $t('contact.otherpeople') }}</div>
       </div>
 
-      <div class="w-1/12 flex items-center">
+      <div class="flex items-center">
         <button
           :id="id"
           class="btn-round"
@@ -82,9 +82,10 @@ button.btn-round {
   background-size: 58px 56px;
   height: 58px;
   width: 56px;
+  min-width: 58px !important;
 }
-@media (max-width: 768px) {
-  .left {
+@media (max-width: 767px) {
+  .leftBorder {
     @apply hidden;
   }
 }

--- a/components/engagement/EngShowContacts.vue
+++ b/components/engagement/EngShowContacts.vue
@@ -2,7 +2,7 @@
   <!-- eslint-disable vue/singleline-html-element-content-newline -->
   <div>
     <div
-      class="grid grid-cols-12 leading-10 bdr bottom top pt-6 pb-6 px-2"
+      class="grid grid-cols-12 leading-10 bdr bottom pt-6 pb-6 px-2"
       :class="[index == 0 ? 'first' : '']"
     >
       <div class="col-span-12 sm:col-span-10 md:col-span-6">

--- a/components/engagement/EngTags.vue
+++ b/components/engagement/EngTags.vue
@@ -21,6 +21,6 @@ export default {
 
 <style scoped>
     .tags {
-        @apply flex bg-rmp-lt-blue text-rmp-dk-blue rounded-full py-2 px-4 items-center
+        @apply flex bg-rmp-lt-blue text-rmp-dk-blue rounded-full my-2 py-2 px-4 items-center
     }
 </style>

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -218,6 +218,6 @@ export default {
     ContactCreated: 'Contact Created',
     ContactUpdated: 'Contact Updated',
     EngagementCreated: 'Engagement Created',
-    EngagementUpdated: 'EngagementUpdated'
+    EngagementUpdated: 'Engagement Updated'
   }
 }


### PR DESCRIPTION
## Description
**Task 289** https://taiga.dts-stn.com/project/pond-knowlege-management-portal/issue/289?kanban-status=99

Updated the ContactSelected component to display middle section of data only on full size 
updated the css and classes to avoid double lines in between elements when more than one selected  

**Task 291** styling the Tags on mobile because when adding 3 it was running out of space, 
  now the tags display vertically on mobile and in-line when on full size 

**Task 292** removed goBack after creating an engagement and added $v.reset to avoid errors on a clean form.

## Test Instructions

1. Steps to reproduce:
    On mobile: Add a new Engagement, select one or more contacts to populate the contact list 
    Expected Results:
          Contact list items are fully visible

1. while on mobile add 2 or 3 tags. tags will now display vertically. change to min-size 768px (ipad) tags will be in-line


## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
