### PR TITLE
button to add tag

### DIFF
--- a/components/engagement/EngForm.vue
+++ b/components/engagement/EngForm.vue
@@ -208,6 +208,9 @@
                 @input="$v.inputTag.$touch()"
                 @keydown.enter.prevent="getTagFromInput()"
               />
+              <button class="addTag" @click.prevent="getTagFromInput()">
+                +
+              </button>
             </div>
             <p v-if="$v.inputTag && !$v.inputTag.maxChar" class="error">
               {{ $t('engagementValidation.maxTagLength') }}
@@ -460,6 +463,9 @@ export default {
   background-image: url('../../assets/images/orange-star.png');
   background-repeat: no-repeat;
   @apply mt-6 pl-6 pr-4 font-bold;
+}
+.addTag{
+  @apply bg-rmp-orange text-white p-2 pl-3 pr-3 rounded-r-lg -ml-1 items-center;
 }
 .dateStyle {
   @apply appearance-none block w-full bg-white border-2  border-gray-400 rounded py-3 px-4 leading-tight;

--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -141,7 +141,7 @@ export default {
     editDescription: 'Description ',
     policy: 'Policy / program',
     tags: 'Tags',
-    tagLabel: 'Start typing and press enter to add new tags',
+    tagLabel: 'Press enter or click + to add new tags',
     comments: 'Comments',
     editComments: 'Comments ',
     cancel: 'Cancel',

--- a/lang/fr-FR.js
+++ b/lang/fr-FR.js
@@ -142,7 +142,7 @@ export default {
     editDescription: 'Description',
     policy: 'Politique / programme',
     tags: 'Mots clés',
-    tagLabel: 'Commencez à taper et sélectionnez la balise existante ou appuyez sur Entrée pour ajouter de nouvelles balises',
+    tagLabel: 'Appuyez sur Entrée ou cliquez sur + pour ajouter de nouvelles balises',
     comments: 'Commentaires',
     editComments: 'Commentaires ',
     cancel: 'Annuler',


### PR DESCRIPTION
# Description

Add a button to the tag field, user can now click the button to add tags

## Test Instructions

- go to the enagegment form
- click on the + button to add tags

## Reviewers 

@bcloutier7 @will0684 @MarcoGoC @shewood @andr0272 @nghe0001 

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
