### PR TITLE
 289 - added breal to avoid long titles to push garbage icon out of view

### DIFF
--- a/components/engagement/EngSelectedContact.vue
+++ b/components/engagement/EngSelectedContact.vue
@@ -2,11 +2,13 @@
   <!-- eslint-disable vue/singleline-html-element-content-newline -->
   <div>
     <div class="flex max-w-full leading-10 bdr bottom pt-6 pb-6" :class="[arrayIndex == 0 ? 'first' : '']">
-      <div class="pl-2 w-full lg:w-6/12">
+      <div class="pl-2 w-6/12">
         <div>
           <span class="orangeText pr-0">{{ name }}</span>, {{ orgname }}
         </div>
-        <div><a :href="'mailto:'+ email">{{ email }}</a></div>
+        <div>
+          <a :href="'mailto:' + email">{{ email }}</a>
+        </div>
       </div>
 
       <div class="w-5/12 bdr leftBorder">
@@ -74,11 +76,8 @@ export default {
 .bottom {
   @apply border-b-2;
 }
-.top {
-  @apply border-t-2;
-}
 button.btn-round {
-  background-image: url('../../assets/images/garbage.svg') ;
+  background-image: url('../../assets/images/garbage.svg');
   background-size: 58px 56px;
   height: 58px;
   width: 56px;


### PR DESCRIPTION
# Description

long titles or email address push the gargaba can out of view, still looks bad, but

## Test Instructions

1. Go to Add or Edit engagements on mobile select a contact with a long name or email 
1. everything wraps but garbage can is still visible 

