### PR TITLE
 re-added break-all to avoid long titles to push garbage icon out of view

### DIFF
--- a/components/engagement/EngSelectedContact.vue
+++ b/components/engagement/EngSelectedContact.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- eslint-disable vue/singleline-html-element-content-newline -->
   <div>
-    <div class="flex max-w-full leading-10 bdr bottom pt-6 pb-6" :class="[arrayIndex == 0 ? 'first' : '']">
+    <div class="flex max-w-full break-all leading-10 bdr bottom pt-6 pb-6" :class="[arrayIndex == 0 ? 'first' : '']">
       <div class="pl-2 w-6/12">
         <div>
           <span class="orangeText pr-0">{{ name }}</span>, {{ orgname }}


### PR DESCRIPTION
## Description

for some reason while fighting with the linting the break-all was lost 
re-adding it 

## Test Instructions

 1. Go to Add or Edit engagements on mobile select a contact with a long name or email
    everything wraps but garbage can is still visible

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
