### PR TITLE
Engagement search now iterates over tags and contact names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9496,11 +9496,6 @@
       "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
       "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw="
     },
-    "es6-promise": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
-      "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM="
-    },
     "escape-goat": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/escape-goat/-/escape-goat-2.1.1.tgz",
@@ -17913,11 +17908,6 @@
       "requires": {
         "aproba": "^1.1.1"
       }
-    },
-    "rx": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
-      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
     },
     "rxjs": {
       "version": "6.5.5",

--- a/pages/search/engagement.vue
+++ b/pages/search/engagement.vue
@@ -61,7 +61,7 @@ export default {
 
   methods: {
     filter(input) {
-      const searchText = input.toLowerCase()
+      const searchText = input.toLowerCase().trim()
 
       const results = this.engagements.filter((engagement) => {
         const values = Object.values(engagement)

--- a/pages/search/engagement.vue
+++ b/pages/search/engagement.vue
@@ -68,8 +68,12 @@ export default {
         let flag = false
 
         values.forEach((val) => {
-          if (Array.isArray(val) && typeof val[0] === 'object') {
-            return
+          if (Array.isArray(val) && typeof val[0] === 'object' && val[0].keyContactName !== undefined) {
+            val.forEach((v) => {
+              if (v.keyContactName.toLowerCase().includes(searchText)) {
+                flag = true
+              }
+            })
           }
           if (Array.isArray(val) && typeof val[0] === 'string') {
             val.forEach((v) => {

--- a/pages/search/engagement.vue
+++ b/pages/search/engagement.vue
@@ -68,10 +68,17 @@ export default {
         let flag = false
 
         values.forEach((val) => {
-          if (typeof val !== 'string') {
+          if (Array.isArray(val) && typeof val[0] === 'object') {
             return
           }
-          if (val.toLowerCase().includes(searchText)) {
+          if (Array.isArray(val) && typeof val[0] === 'string') {
+            val.forEach((v) => {
+              if (v.toLowerCase().includes(searchText)) {
+                flag = true
+              }
+            })
+          }
+          if (typeof val === 'string' && val.toLowerCase().includes(searchText)) {
             flag = true
           }
         })

--- a/tools/seeder/seeder.js
+++ b/tools/seeder/seeder.js
@@ -62,7 +62,7 @@ const populateDatabase = async() => {
   for (let j = 0; j < numEngagements; j++) {
     await Engagements.create({
       type: Randomizers.randomEngagementType(),
-      subject: Randomizers.randomString(10),
+      subject: `Subject-#${j}`,
       date: Randomizers.randomDateBeforeDate(new Date(), -7),
       description: Randomizers.randomString(150),
       numParticipants: Randomizers.randomInt(2, 5),


### PR DESCRIPTION
# Description

[[Bug] #309 Engagement Search does not support tags](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/309?kanban-status=72)
[[Bug] #310 Engagement search by contact name](https://taiga.dts-stn.com/project/pond-knowlege-management-portal/task/310?kanban-status=72)

Engagement search now supports searching over tags and contacts keyContactName.

## Test Instructions

1. Search for engagements by tag
1. Search for engagements by contact

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
