### PR TITLE
313 error message Box size on mobile

### DIFF
--- a/components/engagement/EngEditForm.vue
+++ b/components/engagement/EngEditForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div ref="top" title="engagementEditForm" class="engagementForm font-body mx-2 sm:mx-12 xl:mx-16">
-    <div v-if="attemptSubmit && invalidFields.length" ref="messageBox" class="error-list mt-6">
+    <div v-if="attemptSubmit && invalidFields.length" ref="messageBox" class="error-list w-full md:w-1/2 mt-6">
       <h1 class="text-xl text-red-600">
         {{ $t('engagementValidation.messageTitle') }}
       </h1>
@@ -512,7 +512,6 @@ export default {
   @apply appearance-none border border-red-500 rounded w-full
 }
 .error-list {
-  width: 50%;
   background-color: rgba(255,0,0,0.1);
   @apply border border-red-500;
 }


### PR DESCRIPTION
# Description

Task 313

re - added css for Error Message Box so that it is full width on mobile on Edit Engagement
=> Sheila noticed this bug first

## Test Instructions

1. Go to edit and engagement, delete the subject and submit 
1. on mobile the error message should be full width

## Checklist
- [ ] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
