### PR TITLE
Match "engagement type" strings in seeder and frontend

### DIFF
--- a/lang/en-CA.js
+++ b/lang/en-CA.js
@@ -182,18 +182,18 @@ export default {
     add: 'Add more contacts'
   },
   engagementTypes: {
-    one: 'One-on-one',
+    one: 'One-On-One',
     Conference: 'Conference',
-    ConferenceCall: 'Conference call',
+    ConferenceCall: 'Conference Call',
     Workshop: 'Workshop',
     Webinar: 'Webinar',
-    PhoneCall: 'Phone call',
-    CommitteeMeeting: 'Committee meeting',
-    WorkingGroup: 'Working group',
-    SeniorManagementBriefing: 'Senior management briefing',
-    MinisterOfficeBriefing: 'Minister office briefing',
+    PhoneCall: 'Phone Call',
+    CommitteeMeeting: 'Committee Meeting',
+    WorkingGroup: 'Working Group',
+    SeniorManagementBriefing: 'Senior Management Briefing',
+    MinisterOfficeBriefing: 'Minister Office Briefing',
     ScrumSprint: 'Scrum/Sprint',
-    Advisory: 'Advisory board/Council Meeting'
+    Advisory: 'Advisory Board/Council Meeting'
   },
   dashboard: {
     title: 'Engagement Dashboard',

--- a/tools/seeder/randomizers.js
+++ b/tools/seeder/randomizers.js
@@ -24,10 +24,10 @@ export function randomEngagementType() {
     'Workshop',
     'Webinar',
     'Phone Call',
-    'Committee meeting',
+    'Committee Meeting',
     'Working Group',
-    'Senior management Briefing',
-    'Minister Office briefing',
+    'Senior Management Briefing',
+    'Minister Office Briefing',
     'Scrum/Sprint',
     'Advisory Board/Council Meeting'
   ]


### PR DESCRIPTION
# Description

This ensures the Engagement type dropdown is populated when editing.

## Test Instructions

1. View engagement and select Edit
1. See Engagement Type dropdown is populated

## Help Requested

- If I missed a string let me know

## Checklist
- [x] Strings use placeholders for translation (No hard coded strings)
- [ ] Unit tests have been added/updated
